### PR TITLE
ci: refresh immutable GitHub Actions pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out the published release tag
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
@@ -40,7 +40,7 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Preserve checked distributions
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-distributions
           path: dist/
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Retrieve checked distributions
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-distributions
           path: dist/

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -11,6 +11,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "publish.yml"
+CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 VERIFY_SCRIPT = REPO_ROOT / "scripts" / "verify_release_tag.py"
 CHECKOUT_V7_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
 UPLOAD_ARTIFACT_V7_SHA = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
@@ -97,3 +98,16 @@ def test_publish_workflow_builds_checked_out_release_tag_with_immutable_actions(
         "name": "release-distributions",
         "path": "dist/",
     }
+
+
+def test_ci_workflow_uses_immutable_checkout_v7():
+    workflow = yaml.safe_load(CI_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    checkout_steps = [
+        step
+        for job in workflow["jobs"].values()
+        for step in job["steps"]
+        if step.get("uses", "").startswith("actions/checkout@")
+    ]
+
+    assert len(checkout_steps) == 2
+    assert all(step["uses"] == f"actions/checkout@{CHECKOUT_V7_SHA}" for step in checkout_steps)

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -12,9 +12,9 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "publish.yml"
 VERIFY_SCRIPT = REPO_ROOT / "scripts" / "verify_release_tag.py"
-CHECKOUT_V7_SHA = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
-UPLOAD_ARTIFACT_V4_SHA = "ea165f8d65b6e75b540449e92b4886f43607fa02"
-DOWNLOAD_ARTIFACT_V4_SHA = "d3f86a106a0bac45b974a628896c90dbdf5c8093"
+CHECKOUT_V7_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+UPLOAD_ARTIFACT_V7_SHA = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+DOWNLOAD_ARTIFACT_V8_SHA = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
 
 
 def test_release_tag_verifier_accepts_only_matching_v_prefixed_version(tmp_path):
@@ -86,13 +86,13 @@ def test_publish_workflow_builds_checked_out_release_tag_with_immutable_actions(
     download = next(
         step for step in publish["steps"] if step.get("uses", "").startswith("actions/download-artifact@")
     )
-    assert upload["uses"] == f"actions/upload-artifact@{UPLOAD_ARTIFACT_V4_SHA}"
+    assert upload["uses"] == f"actions/upload-artifact@{UPLOAD_ARTIFACT_V7_SHA}"
     assert upload["with"] == {
         "name": "release-distributions",
         "path": "dist/",
         "if-no-files-found": "error",
     }
-    assert download["uses"] == f"actions/download-artifact@{DOWNLOAD_ARTIFACT_V4_SHA}"
+    assert download["uses"] == f"actions/download-artifact@{DOWNLOAD_ARTIFACT_V8_SHA}"
     assert download["with"] == {
         "name": "release-distributions",
         "path": "dist/",


### PR DESCRIPTION
Updates LintLang CI and release workflows to the current immutable action revisions already proposed separately by Dependabot.

Changes:
- checkout 7.0.1 in CI and publish workflows
- upload-artifact 7.0.1 and download-artifact 8.0.1 in publish
- regression coverage for every updated workflow pin

Root cause:
The three individual Dependabot PRs updated workflow SHAs without updating the repository pin contract, so their Python matrix checks failed.

Local verification:
- 384 tests and 76 subtests passed
- Ruff passed
- real pre-commit LintLang hook passed
- clean-sample CLI smoke passed
- local CodeRabbit review completed with zero findings
- Hermes Gate reported NOT_CONFIGURED; no gate infrastructure was added mid-change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated build, testing, publishing, and artifact workflows to use newer, immutable action versions.
  - Improved consistency across workflow steps by standardizing pinned action revisions.

- **Tests**
  - Expanded workflow validation to confirm checkout actions use the approved immutable revision.
  - Updated artifact-related checks to reflect the current workflow action versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->