### PR TITLE
docs: align public examples with LintLang 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ jobs:
   lint-agent-instructions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Inspect agent instructions
         uses: hermes-labs-ai/lintlang@v0.4.1
@@ -242,7 +242,7 @@ permissions:
   security-events: write
 
 steps:
-  - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+  - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
   - name: Run LintLang
     uses: hermes-labs-ai/lintlang@v0.4.1
     with:

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Inspect agent instructions
-        uses: hermes-labs-ai/lintlang@v0.4.0
+        uses: hermes-labs-ai/lintlang@v0.4.1
         with:
           path: AGENTS.md
 ```
@@ -181,7 +181,7 @@ to scan:
 ```yaml
 repos:
   - repo: https://github.com/hermes-labs-ai/lintlang
-    rev: v0.4.0
+    rev: v0.4.1
     hooks:
       - id: lintlang
         args: [AGENTS.md]
@@ -244,7 +244,7 @@ permissions:
 steps:
   - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   - name: Run LintLang
-    uses: hermes-labs-ai/lintlang@v0.4.0
+    uses: hermes-labs-ai/lintlang@v0.4.1
     with:
       path: AGENTS.md
       fail-on: fail

--- a/examples/github-code-scanning.yml
+++ b/examples/github-code-scanning.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run LintLang
-        uses: hermes-labs-ai/lintlang@v0.4.0
+        uses: hermes-labs-ai/lintlang@v0.4.1
         with:
           path: AGENTS.md
           fail-on: fail

--- a/examples/github-code-scanning.yml
+++ b/examples/github-code-scanning.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run LintLang
         uses: hermes-labs-ai/lintlang@v0.4.1

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -158,7 +158,7 @@ automatically normalized.
 GitHub Actions:
 ```yaml
 - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-- uses: hermes-labs-ai/lintlang@v0.4.0
+- uses: hermes-labs-ai/lintlang@v0.4.1
   with:
     path: configs/
 ```
@@ -167,7 +167,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/hermes-labs-ai/lintlang
-    rev: v0.4.0
+    rev: v0.4.1
     hooks:
       - id: lintlang
         args: [AGENTS.md]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -157,7 +157,7 @@ automatically normalized.
 
 GitHub Actions:
 ```yaml
-- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 - uses: hermes-labs-ai/lintlang@v0.4.1
   with:
     path: configs/

--- a/tests/test_precommit_metadata.py
+++ b/tests/test_precommit_metadata.py
@@ -33,7 +33,7 @@ def test_public_docs_show_exercised_install_and_hook_paths():
         assert "pipx install lintlang" in text
         assert "pipx ensurepath" in text
         assert "repo: https://github.com/hermes-labs-ai/lintlang" in text
-        assert "rev: v0.4.0" in text
+        assert "rev: v0.4.1" in text
         assert f"actions/checkout@{CHECKOUT_V7_SHA}" in text
         assert "actions/checkout@v7" not in text
         assert "id: lintlang" in text

--- a/tests/test_precommit_metadata.py
+++ b/tests/test_precommit_metadata.py
@@ -9,6 +9,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HOOKS = yaml.safe_load((REPO_ROOT / ".pre-commit-hooks.yaml").read_text(encoding="utf-8"))
 CHECKOUT_V7_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+LINTLANG_ACTION_VERSION = "v0.4.1"
 
 
 def test_precommit_hook_is_explicit_and_advisory_by_default():
@@ -43,3 +44,5 @@ def test_public_docs_show_exercised_install_and_hook_paths():
     for text in (readme, code_scanning_example, reference):
         assert f"actions/checkout@{CHECKOUT_V7_SHA} # v7.0.1" in text
         assert "actions/checkout@v7" not in text
+        assert f"hermes-labs-ai/lintlang@{LINTLANG_ACTION_VERSION}" in text
+        assert "hermes-labs-ai/lintlang@v0.4.0" not in text

--- a/tests/test_precommit_metadata.py
+++ b/tests/test_precommit_metadata.py
@@ -8,7 +8,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HOOKS = yaml.safe_load((REPO_ROOT / ".pre-commit-hooks.yaml").read_text(encoding="utf-8"))
-CHECKOUT_V7_SHA = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+CHECKOUT_V7_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
 
 
 def test_precommit_hook_is_explicit_and_advisory_by_default():
@@ -27,6 +27,9 @@ def test_precommit_hook_is_explicit_and_advisory_by_default():
 def test_public_docs_show_exercised_install_and_hook_paths():
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     reference = (REPO_ROOT / "llms-full.txt").read_text(encoding="utf-8")
+    code_scanning_example = (
+        REPO_ROOT / "examples" / "github-code-scanning.yml"
+    ).read_text(encoding="utf-8")
 
     for text in (readme, reference):
         assert "uvx lintlang scan AGENTS.md" in text
@@ -34,7 +37,9 @@ def test_public_docs_show_exercised_install_and_hook_paths():
         assert "pipx ensurepath" in text
         assert "repo: https://github.com/hermes-labs-ai/lintlang" in text
         assert "rev: v0.4.1" in text
-        assert f"actions/checkout@{CHECKOUT_V7_SHA}" in text
-        assert "actions/checkout@v7" not in text
         assert "id: lintlang" in text
         assert "args: [AGENTS.md, --fail-on, fail]" in text
+
+    for text in (readme, code_scanning_example, reference):
+        assert f"actions/checkout@{CHECKOUT_V7_SHA} # v7.0.1" in text
+        assert "actions/checkout@v7" not in text


### PR DESCRIPTION
Aligns every copy-paste public usage surface with the released LintLang 0.4.1 tag and the current immutable checkout 7.0.1 revision.

Changes:
- README Action and pre-commit examples use LintLang v0.4.1
- code-scanning example uses LintLang v0.4.1 and checkout 7.0.1
- model-facing llms-full examples use the same released tag and checkout pin
- metadata regression test covers all three checkout surfaces

Verification:
- 384 tests and 76 subtests passed
- Ruff passed
- focused metadata tests passed with a verified red-to-green cycle
- example YAML parsed successfully
- diff hygiene passed

The local CodeRabbit service was attempted once but did not reach a terminal result within the bounded review window; GitHub CI and the automatic PR CodeRabbit review remain the public gates.