### PR TITLE
docs: link LintLang product page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Python](https://img.shields.io/pypi/pyversions/lintlang)](https://pypi.org/project/lintlang/)
 [![License](https://img.shields.io/pypi/l/lintlang)](LICENSE)
 
+**Product page:** [hermes-labs.ai/lintlang](https://hermes-labs.ai/lintlang)
+
 **LintLang statically analyzes the natural-language instructions that control
 AI agents, catching ambiguous tools, missing limits, and conflicting directives
 before runtime.**


### PR DESCRIPTION
## Summary\n\n- add one above-fold LintLang product-page link to the README\n- leave existing product copy and package metadata unchanged\n\n## Validation\n\n- git diff --check\n- product URL: HTTP 200 with canonical URL preserved\n- ruff check src/ tests/\n- pytest: 384 passed, 76 subtests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Product page link beneath the README badges for easier access to product information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->