### PR TITLE
ci: automate tag releases with version parity

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           python scripts/verify_release_tag.py --tag "$RELEASE_TAG"
           test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "$RELEASE_TAG")"
+          python scripts/sync-version-docs.py --version "${RELEASE_TAG#v}" --check
 
       - name: Build package
         run: python -m build

--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -1,0 +1,90 @@
+name: Release, publish, and version parity
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_call:
+    inputs:
+      tag:
+        description: Existing v-prefixed release tag to publish
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-sync-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: python -m pip install build twine
+
+      - name: Verify tag and documentation parity
+        run: |
+          python scripts/verify_release_tag.py --tag "$RELEASE_TAG"
+          test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "$RELEASE_TAG")"
+          python scripts/sync-version-docs.py --version "${RELEASE_TAG#v}" --check
+
+      - name: Build wheel
+        run: python -m build --wheel
+
+      - name: Check wheel metadata
+        run: python -m twine check dist/*
+
+      - name: Preserve checked wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-wheel
+          path: dist/*.whl
+          if-no-files-found: error
+
+  github-release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+
+    steps:
+      - name: Retrieve checked wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-wheel
+          path: dist/
+
+      - name: Publish GitHub Release with generated changelog
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" dist/*.whl --clobber --repo "$GITHUB_REPOSITORY"
+          else
+            gh release create "$RELEASE_TAG" dist/*.whl \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --title "$RELEASE_TAG" \
+              --generate-notes
+          fi

--- a/scripts/sync-version-docs.py
+++ b/scripts/sync-version-docs.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Synchronize release-bearing LintLang references in product documentation."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+VERSION = r"[0-9]+\.[0-9]+\.[0-9]+(?:[A-Za-z0-9.+!-]*)"
+REPLACEMENTS = (
+    (re.compile(rf"(LINTLANG v){VERSION}"), r"\g<1>{version}"),
+    (re.compile(rf"(\blintlang\s+v?){VERSION}"), r"\g<1>{version}"),
+    (re.compile(rf"(hermes-labs-ai/lintlang@v){VERSION}"), r"\g<1>{version}"),
+    (re.compile(rf"(^[ \t]*rev:[ \t]*v){VERSION}", re.MULTILINE), r"\g<1>{version}"),
+)
+
+
+def product_docs(root: Path) -> list[Path]:
+    candidates = [root / "README.md", root / "llms.txt", root / "llms-full.txt"]
+    candidates.extend(sorted((root / "docs").rglob("*.md")))
+    return [path for path in candidates if path.is_file()]
+
+
+def synchronized(text: str, version: str) -> str:
+    for pattern, replacement in REPLACEMENTS:
+        text = pattern.sub(replacement.format(version=version), text)
+    return text
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args(argv)
+
+    if re.fullmatch(VERSION, args.version) is None:
+        parser.error("--version must be a three-component release version")
+
+    changed: list[Path] = []
+    root = args.root.resolve()
+    for path in product_docs(root):
+        before = path.read_text(encoding="utf-8")
+        after = synchronized(before, args.version)
+        if after == before:
+            continue
+        changed.append(path)
+        if not args.check:
+            path.write_text(after, encoding="utf-8")
+
+    for path in changed:
+        print(path.relative_to(root))
+    return int(args.check and bool(changed))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -79,6 +79,8 @@ def test_publish_workflow_builds_checked_out_release_tag_with_immutable_actions(
     }
     assert verify["env"] == {"RELEASE_TAG": "${{ github.event.release.tag_name }}"}
     assert "scripts/verify_release_tag.py" in verify["run"]
+    assert "scripts/sync-version-docs.py" in verify["run"]
+    assert "--check" in verify["run"]
     assert "git rev-list -n 1" in verify["run"]
     assert any(step.get("run") == "python -m build" for step in steps)
     assert any(step.get("run") == "python -m twine check dist/*" for step in steps)

--- a/tests/test_systemic_automation.py
+++ b/tests/test_systemic_automation.py
@@ -1,0 +1,91 @@
+"""Contracts for the zero-touch automation assets."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-sync.yml"
+SYNC_SCRIPT = REPO_ROOT / "scripts" / "sync-version-docs.py"
+
+
+def load_sync_script():
+    spec = importlib.util.spec_from_file_location("sync_version_docs", SYNC_SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["sync_version_docs"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def project_version() -> str:
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', text)
+    assert match
+    return match.group(1)
+
+
+def test_release_workflow_is_tag_driven_read_only_and_publishes_a_release():
+    text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(text)
+    jobs = workflow["jobs"]
+
+    assert 'tags:\n      - "v*"' in text
+    assert "workflow_call:" in text
+    assert set(jobs) == {"build", "github-release"}
+    assert all(
+        job.get("permissions", {}).get("contents") != "write"
+        for name, job in jobs.items()
+        if name != "github-release"
+    )
+    build_run = "\n".join(str(step.get("run", "")) for step in jobs["build"]["steps"])
+    release_run = "\n".join(str(step.get("run", "")) for step in jobs["github-release"]["steps"])
+    assert "python -m build --wheel" in build_run
+    assert "scripts/sync-version-docs.py" in build_run
+    assert "--check" in build_run
+    assert "git push" not in text
+    assert "--generate-notes" in release_run
+    action_steps = [step for job in jobs.values() for step in job["steps"] if "uses" in step]
+    assert all(re.fullmatch(r"[^@]+@[0-9a-f]{40}", step["uses"]) for step in action_steps)
+
+
+def test_repository_docs_are_already_version_synced():
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SYNC_SCRIPT),
+            "--version",
+            project_version(),
+            "--root",
+            str(REPO_ROOT),
+            "--check",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_version_sync_does_not_rewrite_unrelated_historical_pins():
+    sync = load_sync_script()
+    text = (
+        "LINTLANG v0.4.1\n"
+        "Excerpt from `lintlang 0.4.1`\n"
+        "uses: hermes-labs-ai/lintlang@v0.4.1\n"
+        "rev: v0.4.1\n"
+        "An ecosystem example pins lintlang==0.3.1.\n"
+    )
+    updated = sync.synchronized(text, "0.5.0")
+
+    assert "LINTLANG v0.5.0" in updated
+    assert "`lintlang 0.5.0`" in updated
+    assert "lintlang@v0.5.0" in updated
+    assert "rev: v0.5.0" in updated
+    assert "lintlang==0.3.1" in updated


### PR DESCRIPTION
Adds a lean tag-to-release workflow that checks tag and documentation parity, builds and validates the wheel, and creates the GitHub Release. The existing trusted PyPI workflow remains the publishing handoff.\n\nVerified locally: 6 focused workflow/parity tests, actionlint, and clean diff checks.