### PR TITLE
ci: add trusted-publish recovery dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,18 +3,26 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing v-prefixed release tag to publish
+        required: true
+        type: string
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
 
     steps:
       - name: Check out the published release tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -27,8 +35,6 @@ jobs:
         run: python -m pip install build twine
 
       - name: Verify release tag and commit
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           python scripts/verify_release_tag.py --tag "$RELEASE_TAG"
           test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "$RELEASE_TAG")"

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -49,10 +49,15 @@ def test_release_tag_verifier_accepts_only_matching_v_prefixed_version(tmp_path)
 
 def test_publish_workflow_builds_checked_out_release_tag_with_immutable_actions():
     workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    triggers = workflow[True]
+    assert triggers["release"] == {"types": ["published"]}
+    assert triggers["workflow_dispatch"]["inputs"]["tag"]["required"] is True
     assert set(workflow["jobs"]) == {"build", "publish"}
     build = workflow["jobs"]["build"]
     publish = workflow["jobs"]["publish"]
     assert build["permissions"] == {"contents": "read"}
+    release_tag = "${{ github.event.release.tag_name || inputs.tag }}"
+    assert build["env"] == {"RELEASE_TAG": release_tag}
     assert "environment" not in build
     assert publish["needs"] == "build"
     assert publish["environment"] == "pypi"
@@ -73,11 +78,11 @@ def test_publish_workflow_builds_checked_out_release_tag_with_immutable_actions(
     ))
     assert steps.index(checkout) < steps.index(next(step for step in steps if step.get("name") == "Build package"))
     assert checkout["with"] == {
-        "ref": "${{ github.event.release.tag_name }}",
+        "ref": release_tag,
         "fetch-depth": 0,
         "persist-credentials": False,
     }
-    assert verify["env"] == {"RELEASE_TAG": "${{ github.event.release.tag_name }}"}
+    assert "env" not in verify
     assert "scripts/verify_release_tag.py" in verify["run"]
     assert "scripts/sync-version-docs.py" in verify["run"]
     assert "--check" in verify["run"]


### PR DESCRIPTION
Adds an explicit, version-verified recovery path for publishing an existing release tag. This closes the GitHub `GITHUB_TOKEN` event-suppression gap: `release-sync` can create a GitHub Release, but that action does not emit another workflow-triggering release event.\n\nThe dispatch checks out the requested tag and runs the same tag/package/doc parity, build, Twine, and trusted-publishing jobs.\n\nValidation: 396 passed, 76 subtests; Ruff and actionlint clean.