### PR TITLE
feat: add native Hermes Agent pre-verify hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,30 @@ The release tag pins both the action and the LintLang source it installs.
 Upgrade that pin deliberately and inspect newly introduced findings before
 making them blocking.
 
+## Hermes Agent verification hook
+
+When LintLang and [Hermes Agent](https://github.com/NousResearch/hermes-agent)
+are installed in the same Python environment, Hermes discovers LintLang through
+its native `hermes_agent.plugins` entry-point contract. LintLang registers one
+bounded `pre_verify` hook: after a coding turn changes a recognized agent
+instruction, prompt, skill, tool, or agent-config surface, it runs the same
+local deterministic scan before the turn finishes.
+
+`PASS` and `REVIEW` do not interrupt the turn. `FAIL` or an input `ERROR` keeps
+the turn open once with the exact `lintlang scan` command to run. The hook
+self-throttles on Hermes' `attempt` field and ignores ordinary source and
+documentation files, so it cannot create an unbounded retry loop or turn a
+general code edit into a prompt-lint gate.
+
+Verify discovery with:
+
+```bash
+hermes plugins list
+```
+
+Disable the `lintlang` plugin through Hermes' normal plugin controls if the
+workspace should use only LintLang's CI or pre-commit surfaces.
+
 ## Add it to pre-commit
 
 Add the hook to `.pre-commit-config.yaml` with the explicit instruction paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ dev = [
 [project.scripts]
 lintlang = "lintlang.cli:main"
 
+[project.entry-points."hermes_agent.plugins"]
+lintlang = "lintlang.integrations.hermes_agent:register"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/lintlang"]
 

--- a/src/lintlang/integrations/__init__.py
+++ b/src/lintlang/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Host-native integration entry points."""

--- a/src/lintlang/integrations/hermes_agent.py
+++ b/src/lintlang/integrations/hermes_agent.py
@@ -1,0 +1,85 @@
+"""Hermes Agent verification hook for changed instruction surfaces.
+
+Hermes Agent discovers this module through its documented
+``hermes_agent.plugins`` entry-point group. The hook is deliberately narrow:
+it runs once, at Hermes' bounded ``pre_verify`` gate, and only for changed
+files whose names or locations identify them as agent instructions, prompts,
+skills, tools, or agent configuration. REVIEW findings remain advisory;
+only FAIL or ERROR keeps the coding turn open.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from lintlang import compute_verdict, scan_file
+
+_EXACT_NAMES = {
+    ".cursorrules",
+    ".hermes.md",
+    "agents.md",
+    "claude.md",
+    "copilot-instructions.md",
+    "skill.md",
+    "system.md",
+    "system.prompt",
+}
+_LANGUAGE_SUFFIXES = {".json", ".md", ".prompt", ".py", ".txt", ".yaml", ".yml"}
+_PATH_MARKERS = {"agent", "agents", "plugin", "plugins", "prompt", "prompts", "skill", "skills", "tool", "tools"}
+_STEM_MARKERS = ("agent", "instruction", "plugin", "prompt", "skill", "system", "tool")
+
+
+def _is_instruction_surface(path: Path) -> bool:
+    """Return whether a changed path is a plausible LintLang input."""
+    if path.name.lower() in _EXACT_NAMES:
+        return True
+    if path.suffix.lower() not in _LANGUAGE_SUFFIXES:
+        return False
+    lowered_parts = {part.lower() for part in path.parts}
+    return bool(lowered_parts & _PATH_MARKERS) or any(marker in path.stem.lower() for marker in _STEM_MARKERS)
+
+
+def _blocking_summary(paths: Iterable[str]) -> list[str]:
+    """Scan existing eligible files and return concise FAIL/ERROR summaries."""
+    blocked: list[str] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        if not path.is_file() or not _is_instruction_surface(path):
+            continue
+        result = scan_file(path)
+        verdict = compute_verdict(result)
+        if verdict not in {"FAIL", "ERROR"}:
+            continue
+        detail = result.input_error
+        if not detail and result.structural_findings:
+            finding = result.structural_findings[0]
+            detail = f"{finding.code} {finding.description}"
+        blocked.append(f"{path}: {verdict}" + (f" — {detail}" if detail else ""))
+    return blocked
+
+
+def pre_verify(*, coding: bool, attempt: int, changed_paths: list[str], **_: Any) -> dict[str, str] | None:
+    """Keep one Hermes coding turn open when changed agent language fails lint."""
+    if not coding or attempt:
+        return None
+    blocked = _blocking_summary(changed_paths)
+    if not blocked:
+        return None
+    lines = "\n".join(f"- {line}" for line in blocked[:5])
+    suffix = "\n- additional changed inputs omitted" if len(blocked) > 5 else ""
+    return {
+        "action": "continue",
+        "message": (
+            "LintLang found a blocking issue in changed agent-language files:\n"
+            f"{lines}{suffix}\n"
+            "Run `lintlang scan <path> --fail-on fail`, repair or explicitly exclude the input, "
+            "then verify again. A clean scan is structural evidence only, not a runtime-safety claim."
+        ),
+    }
+
+
+def register(ctx: Any) -> None:
+    """Register the bounded verification hook with Hermes Agent."""
+    ctx.register_hook("pre_verify", pre_verify)

--- a/tests/test_hermes_agent_integration.py
+++ b/tests/test_hermes_agent_integration.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from importlib.metadata import EntryPoint
+from pathlib import Path
+
+from lintlang.integrations.hermes_agent import _is_instruction_surface, pre_verify, register
+
+
+class FakePluginContext:
+    def __init__(self) -> None:
+        self.hooks: list[tuple[str, object]] = []
+
+    def register_hook(self, name: str, callback: object) -> None:
+        self.hooks.append((name, callback))
+
+
+def test_registers_documented_pre_verify_hook() -> None:
+    ctx = FakePluginContext()
+    register(ctx)
+    assert ctx.hooks == [("pre_verify", pre_verify)]
+
+
+def test_entry_point_loads_register_function() -> None:
+    entry_point = EntryPoint(
+        name="lintlang",
+        value="lintlang.integrations.hermes_agent:register",
+        group="hermes_agent.plugins",
+    )
+    assert entry_point.load() is register
+
+
+def test_instruction_surface_scope_is_narrow() -> None:
+    assert _is_instruction_surface(Path("AGENTS.md"))
+    assert _is_instruction_surface(Path("plugins/weather/tools.py"))
+    assert not _is_instruction_surface(Path("src/database.py"))
+    assert not _is_instruction_surface(Path("README.md"))
+
+
+def test_fail_keeps_one_coding_turn_open(tmp_path) -> None:
+    prompt = tmp_path / "prompts" / "agent.yaml"
+    prompt.parent.mkdir()
+    prompt.write_text('tools:\n  - name: lookup\n    description: "Do stuff"\n', encoding="utf-8")
+
+    result = pre_verify(coding=True, attempt=0, changed_paths=[str(prompt)])
+
+    assert result is not None
+    assert result["action"] == "continue"
+    assert "lintlang scan" in result["message"]
+    assert str(prompt) in result["message"]
+
+
+def test_pass_review_non_coding_and_retry_do_not_nudge(tmp_path) -> None:
+    prompt = tmp_path / "AGENTS.md"
+    prompt.write_text(
+        "You are a bounded assistant. Use the lookup tool only for current records. "
+        "Stop after one attempt and report any missing record.",
+        encoding="utf-8",
+    )
+
+    assert pre_verify(coding=True, attempt=0, changed_paths=[str(prompt)]) is None
+    assert pre_verify(coding=False, attempt=0, changed_paths=[str(prompt)]) is None
+    assert pre_verify(coding=True, attempt=1, changed_paths=[str(prompt)]) is None


### PR DESCRIPTION
## Why

Hermes Agent exposes a native `pre_verify` lifecycle gate immediately before a coding turn with file edits would finish. LintLang already scans the agent-language surfaces involved, so this integration can catch a blocking instruction or tool-description defect inside the external agent loop without adding another model call or duplicating the existing CI and pre-commit integrations.

## What

- register LintLang through the documented `hermes_agent.plugins` entry-point group
- scan only changed instruction, prompt, skill, tool, plugin, and agent-config surfaces
- keep PASS and REVIEW non-blocking
- reopen the turn once for FAIL or input ERROR with the exact repair command
- self-throttle on the host's `attempt` field and ignore ordinary source/docs

## Validation

- full suite: 401 passed, 76 subtests passed
- targeted Ruff: pass
- wheel/sdist build: pass
- built wheel contains the `hermes_agent.plugins` entry point
- focused FAIL, clean, retry, non-coding, and path-scope behaviors pass

A clean scan remains structural evidence only, not a runtime-safety claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hermes Agent integration that automatically scans modified agent instruction files after coding turns.
  * Verification failures or input errors keep the turn open with guidance to repair or exclude affected files.
  * Added plugin discovery and configuration support through Hermes Agent’s standard controls.

* **Documentation**
  * Documented setup, verification, behavior, throttling, and disabling instructions for the Hermes Agent integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->