### PR TITLE
chore: prepare LintLang 0.5.2

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "upload_type": "software",
   "title": "lintlang: static linter for AI agent configs, system prompts, and tool definitions (zero-LLM)",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "lintlang is a deterministic static linter for AI agent configs, system prompts, tool definitions, and embedded Python prompt text. It applies HERM v1.1 scoring, seven structural detector groups (H1-H7), and two Python pipeline checks (P1-P2) without model or network calls. Findings identify bounded heuristic patterns and do not establish runtime correctness, safety, or detector accuracy on external projects.",
   "creators": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## [0.5.1] - Unreleased
+## [0.5.2] - Unreleased
+
+### Added
+
+- Native Hermes Agent `pre_verify` integration that scans changed
+  instruction-bearing files once before a coding turn finishes. `PASS` and
+  `REVIEW` remain non-blocking; `FAIL` or input `ERROR` reopens the turn with
+  the exact local scan command.
+
+## [0.5.1] - 2026-09-02
 
 ### Fixed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: "Rolando"
     orcid: "https://orcid.org/0009-0005-4896-1112"
     affiliation: "Hermes Labs"
-version: "0.5.1"
+version: "0.5.2"
 license: "Apache-2.0"
 repository-code: "https://github.com/hermes-labs-ai/lintlang"
 url: "https://github.com/hermes-labs-ai/lintlang"

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ cd lintlang
 lintlang scan samples/bad_tool_descriptions.yaml --fail-on fail
 ```
 
-Excerpt from `lintlang 0.5.1`:
+Excerpt from `lintlang 0.5.2`:
 
 ```text
-LINTLANG v0.5.1
+LINTLANG v0.5.2
 
 FAIL — 1 CRITICAL, 2 HIGH, 7 MEDIUM, 3 LOW
 
@@ -184,7 +184,7 @@ jobs:
           persist-credentials: false
 
       - name: Inspect agent instructions
-        uses: hermes-labs-ai/lintlang@v0.5.1
+        uses: hermes-labs-ai/lintlang@v0.5.2
         with:
           path: AGENTS.md
 ```
@@ -225,7 +225,7 @@ to scan:
 ```yaml
 repos:
   - repo: https://github.com/hermes-labs-ai/lintlang
-    rev: v0.5.1
+    rev: v0.5.2
     hooks:
       - id: lintlang
         args: [AGENTS.md]

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,15 +4,15 @@
   "name": "lintlang",
   "description": "Static linter for AI agent configs, tool descriptions, and system prompts with zero-LLM CI gating.",
   "codeRepository": "https://github.com/hermes-labs-ai/lintlang",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "https://spdx.org/licenses/Apache-2.0",
   "programmingLanguage": "Python",
   "runtimePlatform": "Python >=3.10",
   "identifier": [
     "https://doi.org/10.5281/zenodo.20471007",
-    "https://pypi.org/project/lintlang/0.5.1/"
+    "https://pypi.org/project/lintlang/0.5.2/"
   ],
   "author": [{"@type": "Person", "givenName": "Rolando", "familyName": "Bosch Rodriguez", "identifier": "https://orcid.org/0009-0005-4896-1112"}],
-  "url": "https://pypi.org/project/lintlang/0.5.1/",
+  "url": "https://pypi.org/project/lintlang/0.5.2/",
   "keywords": ["static analysis", "agent configuration", "prompt linting", "CI gating", "zero-LLM"]
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -158,7 +158,7 @@ automatically normalized.
 GitHub Actions:
 ```yaml
 - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-- uses: hermes-labs-ai/lintlang@v0.5.1
+- uses: hermes-labs-ai/lintlang@v0.5.2
   with:
     path: configs/
 ```
@@ -167,7 +167,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/hermes-labs-ai/lintlang
-    rev: v0.5.1
+    rev: v0.5.2
     hooks:
       - id: lintlang
         args: [AGENTS.md]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lintlang"
-version = "0.5.1"
+version = "0.5.2"
 description = "Static linter for AI agent configs, tool descriptions, and system prompts with zero-LLM CI gating"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/lintlang/__init__.py
+++ b/src/lintlang/__init__.py
@@ -14,7 +14,7 @@ Quick start::
         print(f"  [{f.severity.value}] {f.description}")
 """
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 from lintlang.herm import HermResult, score_text
 from lintlang.patterns import AgentConfig, Finding, Severity

--- a/tests/test_docs_consistency.py
+++ b/tests/test_docs_consistency.py
@@ -65,7 +65,7 @@ def test_unreleased_changelog_avoids_brittle_test_count_claim():
 def test_readme_keeps_regression_methodology_out_of_adoption_path():
     """The main README may show an excerpt without carrying eval methodology."""
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8").lower()
-    assert "excerpt from `lintlang 0.5.1`" in readme
+    assert "excerpt from `lintlang 0.5.2`" in readme
     assert "repository regression check" not in readme
     assert "external-project detector accuracy" not in readme
 

--- a/tests/test_precommit_metadata.py
+++ b/tests/test_precommit_metadata.py
@@ -9,7 +9,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HOOKS = yaml.safe_load((REPO_ROOT / ".pre-commit-hooks.yaml").read_text(encoding="utf-8"))
 CHECKOUT_V7_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
-LINTLANG_ACTION_VERSION = "v0.5.1"
+LINTLANG_ACTION_VERSION = "v0.5.2"
 LINTLANG_GENERATED_ACTION_SHA = "cad2dca3054b8bfb5d0a6b93ecf19f9d74ab64fe"
 
 
@@ -38,7 +38,7 @@ def test_public_docs_show_exercised_install_and_hook_paths():
         assert "pipx install lintlang" in text
         assert "pipx ensurepath" in text
         assert "repo: https://github.com/hermes-labs-ai/lintlang" in text
-        assert "rev: v0.5.1" in text
+        assert "rev: v0.5.2" in text
         assert "id: lintlang" in text
         assert "args: [AGENTS.md, --fail-on, fail]" in text
         assert f"hermes-labs-ai/lintlang@{LINTLANG_ACTION_VERSION}" in text


### PR DESCRIPTION
## Summary

Prepare LintLang 0.5.2 after merging the native Hermes Agent `pre_verify` integration.

- synchronize package, runtime, citation, archive, CodeMeta, and public documentation versions
- record the integration in the changelog
- advance version-bound documentation contract tests

## Validation

- 401 tests passed, 76 subtests passed
- Ruff passed
- `scripts/sync-version-docs.py --version 0.5.2 --check` passed
- `git diff --check` passed
