### PR TITLE
feat: add native Claude Code LintLang repair hook

### DIFF
--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
+  "name": "lintlang",
+  "version": "0.1.0",
+  "description": "Returns concise LintLang repair guidance after Claude Code changes a supported language-bearing file.",
+  "author": {
+    "name": "Hermes Labs",
+    "email": "roli@hermes-labs.ai"
+  },
+  "homepage": "https://lintlang.ai/",
+  "repository": "https://github.com/hermes-labs-ai/lintlang",
+  "license": "Apache-2.0"
+}

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -7,10 +7,10 @@ The adapter never rewrites files and never blocks a tool call.
 
 ## Prerequisites
 
-Install LintLang so `lintlang` is on `PATH`:
+Install the adapter's tested LintLang release so `lintlang` is on `PATH`:
 
 ```bash
-pipx install lintlang
+pipx install lintlang==0.5.2
 ```
 
 ## Try the plugin from this checkout

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -1,0 +1,35 @@
+# LintLang for Claude Code
+
+This native Claude Code plugin runs LintLang after successful `Write` and
+`Edit` tool calls. For supported language-bearing files, findings are returned
+to Claude as concise repair context. Clean or unsupported files add no context.
+The adapter never rewrites files and never blocks a tool call.
+
+## Prerequisites
+
+Install LintLang so `lintlang` is on `PATH`:
+
+```bash
+pipx install lintlang
+```
+
+## Try the plugin from this checkout
+
+```bash
+claude --plugin-dir ./integrations/claude-code
+```
+
+Claude Code also accepts a plugin ZIP through `--plugin-dir` or a hosted ZIP
+through `--plugin-url`. A marketplace may point at this plugin directory when
+the repository is released; users can then install it with
+`claude plugin install lintlang@<marketplace-name>`.
+
+Validate the plugin against the installed Claude Code runtime:
+
+```bash
+claude plugin validate --strict ./integrations/claude-code
+```
+
+The hook supports `.yaml`, `.yml`, `.json`, `.txt`, `.md`, `.prompt`, and `.py`,
+matching LintLang's file scanner. It sends only finding descriptions and repair
+suggestions back to Claude; raw prompt evidence is omitted.

--- a/integrations/claude-code/hooks-handlers/post-tool-use.py
+++ b/integrations/claude-code/hooks-handlers/post-tool-use.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Claude Code PostToolUse adapter for LintLang."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SUPPORTED_SUFFIXES = {".json", ".md", ".prompt", ".py", ".txt", ".yaml", ".yml"}
+MAX_FINDINGS = 8
+
+
+def _emit(context: str | None = None) -> None:
+    output: dict[str, Any] = {}
+    if context:
+        output["hookSpecificOutput"] = {
+            "hookEventName": "PostToolUse",
+            "additionalContext": context,
+        }
+    print(json.dumps(output))
+
+
+def _lintlang_command() -> list[str] | None:
+    executable = shutil.which("lintlang")
+    if executable:
+        return [executable]
+    if importlib.util.find_spec("lintlang") is not None:
+        return [sys.executable, "-m", "lintlang"]
+    return None
+
+
+def _format_result(path: Path, result: dict[str, Any]) -> str | None:
+    input_error = result.get("input_error")
+    if input_error:
+        return f"LintLang could not scan {path}: {input_error}"
+
+    findings = result.get("structural_findings") or []
+    if not findings:
+        return None
+
+    lines = [
+        f"LintLang found {len(findings)} issue(s) in {path} (verdict: {result.get('verdict', 'unknown')}).",
+        "Repair the applicable findings, then keep the user's requested behavior intact:",
+    ]
+    for finding in findings[:MAX_FINDINGS]:
+        code = finding.get("code") or finding.get("pattern_id") or "LintLang"
+        severity = str(finding.get("severity", "unknown")).upper()
+        location = finding.get("location") or "file"
+        description = finding.get("description") or "Issue detected."
+        suggestion = finding.get("suggestion")
+        line = f"- [{severity} {code}] {location}: {description}"
+        if suggestion:
+            line += f" Suggested repair: {suggestion}"
+        lines.append(line)
+    if len(findings) > MAX_FINDINGS:
+        lines.append(
+            f"- {len(findings) - MAX_FINDINGS} additional finding(s) omitted; "
+            f"run `lintlang scan {path}` for all details."
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError):
+        _emit()
+        return 0
+
+    tool_input = event.get("tool_input") or {}
+    raw_path = tool_input.get("file_path")
+    if not isinstance(raw_path, str):
+        raw_path = (event.get("tool_response") or {}).get("filePath")
+    if not isinstance(raw_path, str):
+        _emit()
+        return 0
+
+    path = Path(raw_path)
+    if path.suffix.lower() not in SUPPORTED_SUFFIXES or not path.is_file():
+        _emit()
+        return 0
+
+    command = _lintlang_command()
+    if command is None:
+        _emit(
+            "LintLang could not check the changed file because `lintlang` is not installed. "
+            "Install it with `pipx install lintlang`, then retry the edit or run `lintlang scan <file>`."
+        )
+        return 0
+
+    try:
+        completed = subprocess.run(
+            [*command, "scan", str(path), "--format", "json"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=20,
+        )
+        payload = json.loads(completed.stdout)
+        result = payload[0] if isinstance(payload, list) and payload else None
+        if not isinstance(result, dict):
+            raise ValueError("LintLang returned no file result")
+    except (json.JSONDecodeError, OSError, subprocess.TimeoutExpired, ValueError) as error:
+        _emit(
+            f"LintLang could not check {path}: {error}. "
+            f"Run `lintlang scan {path}` directly for diagnostics."
+        )
+        return 0
+
+    _emit(_format_result(path, result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/claude-code/hooks-handlers/post-tool-use.py
+++ b/integrations/claude-code/hooks-handlers/post-tool-use.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import shlex
 import shutil
 import subprocess
 import sys
@@ -13,6 +14,7 @@ from typing import Any
 
 SUPPORTED_SUFFIXES = {".json", ".md", ".prompt", ".py", ".txt", ".yaml", ".yml"}
 MAX_FINDINGS = 8
+PINNED_VERSION = "0.5.2"
 
 
 def _emit(context: str | None = None) -> None:
@@ -25,12 +27,24 @@ def _emit(context: str | None = None) -> None:
     print(json.dumps(output))
 
 
+def _is_pinned(command: list[str]) -> bool:
+    try:
+        completed = subprocess.run(
+            [*command, "--version"], capture_output=True, check=False, text=True, timeout=3
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0 and completed.stdout.strip() == f"lintlang {PINNED_VERSION}"
+
+
 def _lintlang_command() -> list[str] | None:
-    executable = shutil.which("lintlang")
-    if executable:
-        return [executable]
     if importlib.util.find_spec("lintlang") is not None:
-        return [sys.executable, "-m", "lintlang"]
+        module_command = [sys.executable, "-m", "lintlang"]
+        if _is_pinned(module_command):
+            return module_command
+    executable = shutil.which("lintlang")
+    if executable and _is_pinned([executable]):
+        return [executable]
     return None
 
 
@@ -60,7 +74,7 @@ def _format_result(path: Path, result: dict[str, Any]) -> str | None:
     if len(findings) > MAX_FINDINGS:
         lines.append(
             f"- {len(findings) - MAX_FINDINGS} additional finding(s) omitted; "
-            f"run `lintlang scan {path}` for all details."
+            f"run `lintlang scan -- {shlex.quote(str(path))}` for all details."
         )
     return "\n".join(lines)
 
@@ -88,14 +102,15 @@ def main() -> int:
     command = _lintlang_command()
     if command is None:
         _emit(
-            "LintLang could not check the changed file because `lintlang` is not installed. "
-            "Install it with `pipx install lintlang`, then retry the edit or run `lintlang scan <file>`."
+            f"LintLang could not check the changed file because lintlang {PINNED_VERSION} is not available. "
+            f"Install it with `pipx install lintlang=={PINNED_VERSION}`, then retry the edit or run "
+            "`lintlang scan <file>`."
         )
         return 0
 
     try:
         completed = subprocess.run(
-            [*command, "scan", str(path), "--format", "json"],
+            [*command, "scan", "--format", "json", "--", str(path)],
             capture_output=True,
             check=False,
             text=True,
@@ -108,7 +123,7 @@ def main() -> int:
     except (json.JSONDecodeError, OSError, subprocess.TimeoutExpired, ValueError) as error:
         _emit(
             f"LintLang could not check {path}: {error}. "
-            f"Run `lintlang scan {path}` directly for diagnostics."
+            f"Run `lintlang scan -- {shlex.quote(str(path))}` directly for diagnostics."
         )
         return 0
 

--- a/integrations/claude-code/hooks/hooks.json
+++ b/integrations/claude-code/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks-handlers/post-tool-use.py\"",
+            "timeout": 30,
+            "statusMessage": "Checking changed language with LintLang..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_claude_code_plugin.py
+++ b/tests/test_claude_code_plugin.py
@@ -1,0 +1,51 @@
+"""Contract tests for the native Claude Code plugin adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+HANDLER = ROOT / "integrations/claude-code/hooks-handlers/post-tool-use.py"
+
+
+def _run_hook(path: Path) -> dict:
+    event = {
+        "session_id": "test-session",
+        "tool_name": "Edit",
+        "tool_input": {"file_path": str(path)},
+        "tool_response": {"success": True},
+    }
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT / "src")
+    completed = subprocess.run(
+        [sys.executable, str(HANDLER)],
+        input=json.dumps(event),
+        capture_output=True,
+        check=True,
+        text=True,
+        env=env,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_hook_returns_actionable_repair_context_for_findings(tmp_path: Path) -> None:
+    target = tmp_path / "agent.yaml"
+    target.write_text("tools:\n  - name: lookup\n    description: Get data\n", encoding="utf-8")
+
+    output = _run_hook(target)
+
+    specific = output["hookSpecificOutput"]
+    assert specific["hookEventName"] == "PostToolUse"
+    assert "Suggested repair:" in specific["additionalContext"]
+    assert "evidence" not in specific["additionalContext"].lower()
+
+
+def test_hook_is_silent_for_unsupported_file(tmp_path: Path) -> None:
+    target = tmp_path / "module.js"
+    target.write_text("export const value = 1;\n", encoding="utf-8")
+
+    assert _run_hook(target) == {}

--- a/tests/test_claude_code_plugin.py
+++ b/tests/test_claude_code_plugin.py
@@ -21,6 +21,7 @@ def _run_hook(path: Path) -> dict:
     }
     env = os.environ.copy()
     env["PYTHONPATH"] = str(ROOT / "src")
+    env["PATH"] = ""
     completed = subprocess.run(
         [sys.executable, str(HANDLER)],
         input=json.dumps(event),


### PR DESCRIPTION
Adds a native Claude Code PostToolUse plugin for Write and Edit. It scans supported changed files with LintLang and returns capped, actionable repair context without blocking or rewriting.\n\nEvidence:\n- Claude Code 2.1.259 strict plugin validation passed\n- Claude plugin inventory recognized one PostToolUse hook with zero always-on model tokens\n- Bad fixture produced 13 real findings, capped to eight plus the exact full-scan command\n- Focused adapter tests: 2 passed\n- Hermes Gate full: Ruff plus 403 passed and 76 subtests passed\n- Roli Twin review: PASS\n\nThe existing Hermes plugin is manually invoked; this hook is the automatic changed-file feedback path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Claude Code plugin for automatically checking supported files after edits.
  * Displays LintLang findings and suggested repairs directly in Claude Code.
  * Supports local and hosted plugin installation options.

* **Documentation**
  * Added setup, validation, supported file type, and findings-output guidance.

* **Tests**
  * Added coverage for supported and unsupported file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->