### PR TITLE
Add Gemini CLI file-change extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ pre-commit run lintlang
 Replace or extend `args` with the prompt, tool-definition, agent-configuration,
 or supported directory paths your repository owns. The hook scans only those
 configured paths and reports findings without blocking on a verdict by default.
+
 After reviewing the repository's baseline, opt into blocking `FAIL` findings:
 
 ```yaml
@@ -250,6 +251,14 @@ hooks:
 ```
 
 Missing, unreadable, or malformed configured inputs still return nonzero.
+
+## Use it with Gemini CLI
+
+The repository root is also a Gemini CLI extension. Its non-blocking
+`AfterTool` hook returns LintLang repair guidance after Gemini changes supported
+files with `write_file` or `replace`. See the
+[Gemini CLI extension guide](docs/gemini-cli-extension.md) for the pinned,
+isolated dependency contract and installation steps.
 
 ## Machine-readable output and GitHub Code Scanning
 

--- a/docs/gemini-cli-extension.md
+++ b/docs/gemini-cli-extension.md
@@ -1,0 +1,33 @@
+# Gemini CLI extension
+
+LintLang's repository root is a Gemini CLI extension. Its `AfterTool` hook runs
+after successful `write_file` and `replace` calls, scans supported
+language-bearing files, and appends concise repair guidance to the tool result.
+It does not block or rewrite the file. Clean and unsupported files add no
+context.
+
+## Install
+
+The extension requires [uv](https://docs.astral.sh/uv/) on `PATH`. The hook runs
+the source bundled in the installed extension and asks uv for exactly
+`PyYAML==6.0.3` in an isolated cached environment. It does not depend on an
+ambient `lintlang` installation. The first scan may download that pinned wheel;
+later scans reuse uv's cache.
+
+From a checkout:
+
+```bash
+gemini extensions validate .
+gemini extensions install . --consent
+```
+
+Once the root manifest is released, users can instead install the GitHub
+repository URL. Gemini CLI copies the extension, including `src/lintlang`, into
+its extension directory.
+
+## Behavior
+
+The hook handles `.yaml`, `.yml`, `.json`, `.txt`, `.md`, `.prompt`, and `.py`.
+It returns at most eight findings plus an omitted count, includes stable codes,
+locations, severities, descriptions, and repair suggestions, and omits the raw
+`evidence` field. Hook execution is capped at 30 seconds.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "lintlang",
+  "version": "0.5.2",
+  "description": "Returns concise LintLang repair guidance after Gemini CLI changes language-bearing files."
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "AfterTool": [
+      {
+        "matcher": "^(write_file|replace)$",
+        "hooks": [
+          {
+            "name": "lintlang-after-file-change",
+            "type": "command",
+            "command": "uv run --quiet --no-project --with PyYAML==6.0.3 -- python \"${extensionPath}${/}hooks${/}lintlang_after_tool.py\"",
+            "timeout": 30000,
+            "description": "Scan a successfully changed language-bearing file and return bounded repair guidance."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/lintlang_after_tool.py
+++ b/hooks/lintlang_after_tool.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Gemini CLI AfterTool adapter for the bundled LintLang source."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SUPPORTED_SUFFIXES = {".json", ".md", ".prompt", ".py", ".txt", ".yaml", ".yml"}
+MAX_FINDINGS = 8
+
+
+def _emit(context: str | None = None) -> None:
+    output: dict[str, Any] = {}
+    if context:
+        output["hookSpecificOutput"] = {
+            "hookEventName": "AfterTool",
+            "additionalContext": context,
+        }
+    print(json.dumps(output))
+
+
+def _display_path(path: Path, cwd: str | None) -> str:
+    if cwd:
+        try:
+            return str(path.resolve().relative_to(Path(cwd).resolve()))
+        except ValueError:
+            pass
+    return str(path)
+
+
+def _format_result(path: str, verdict: str, result: Any) -> str | None:
+    if result.input_error:
+        return f"LintLang could not scan {path}: {result.input_error}"
+    findings = result.structural_findings
+    if not findings:
+        return None
+
+    lines = [
+        f"LintLang found {len(findings)} issue(s) in {path} (verdict: {verdict}).",
+        "Repair the applicable findings, then preserve the user's requested behavior:",
+    ]
+    for finding in findings[:MAX_FINDINGS]:
+        severity = finding.severity.value.upper()
+        lines.append(
+            f"- [{severity} {finding.code}] {finding.location}: {finding.description} "
+            f"Suggested repair: {finding.suggestion}"
+        )
+    if len(findings) > MAX_FINDINGS:
+        omitted = len(findings) - MAX_FINDINGS
+        lines.append(f"- {omitted} additional finding(s) omitted; run `lintlang scan {path}` for all details.")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError):
+        _emit()
+        return 0
+
+    if event.get("hook_event_name") != "AfterTool":
+        _emit()
+        return 0
+    if event.get("tool_name") not in {"write_file", "replace"}:
+        _emit()
+        return 0
+    if (event.get("tool_response") or {}).get("error"):
+        _emit()
+        return 0
+
+    raw_path = (event.get("tool_input") or {}).get("file_path")
+    if not isinstance(raw_path, str):
+        _emit()
+        return 0
+
+    cwd = event.get("cwd") if isinstance(event.get("cwd"), str) else None
+    path = Path(raw_path)
+    if not path.is_absolute() and cwd:
+        path = Path(cwd) / path
+    if path.suffix.lower() not in SUPPORTED_SUFFIXES or not path.is_file():
+        _emit()
+        return 0
+
+    extension_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(extension_root / "src"))
+    display_path = _display_path(path, cwd)
+    try:
+        from lintlang.report import compute_verdict
+        from lintlang.scanner import scan_file
+
+        result = scan_file(path)
+        context = _format_result(display_path, compute_verdict(result), result)
+    except Exception as error:
+        context = f"LintLang could not scan {display_path}: {error}. Run `lintlang scan {display_path}` directly."
+
+    _emit(context)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gemini_extension.py
+++ b/tests/test_gemini_extension.py
@@ -1,0 +1,77 @@
+"""Contract tests for the root Gemini CLI extension."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from lintlang import __version__
+
+ROOT = Path(__file__).parents[1]
+HANDLER = ROOT / "hooks/lintlang_after_tool.py"
+
+
+def _run_hook(path: Path, *, tool_name: str = "replace", error: str | None = None) -> dict:
+    event = {
+        "session_id": "test-session",
+        "transcript_path": "/tmp/test-session.json",
+        "cwd": str(path.parent),
+        "hook_event_name": "AfterTool",
+        "timestamp": "2026-09-03T00:00:00Z",
+        "tool_name": tool_name,
+        "tool_input": {"file_path": path.name},
+        "tool_response": {"llmContent": "changed", "returnDisplay": "changed", "error": error},
+    }
+    completed = subprocess.run(
+        [sys.executable, str(HANDLER)],
+        input=json.dumps(event),
+        capture_output=True,
+        check=True,
+        text=True,
+        env=os.environ.copy(),
+    )
+    return json.loads(completed.stdout)
+
+
+def test_root_extension_declares_stable_bounded_hook_contract() -> None:
+    manifest = json.loads((ROOT / "gemini-extension.json").read_text(encoding="utf-8"))
+    config = json.loads((ROOT / "hooks/hooks.json").read_text(encoding="utf-8"))
+    definition = config["hooks"]["AfterTool"][0]
+    hook = definition["hooks"][0]
+
+    assert manifest["name"] == "lintlang"
+    assert manifest["version"] == __version__
+    assert definition["matcher"] == "^(write_file|replace)$"
+    assert hook["timeout"] == 30_000
+    assert "${extensionPath}" in hook["command"]
+    assert "PyYAML==6.0.3" in hook["command"]
+
+
+def test_after_tool_returns_bounded_actionable_context(tmp_path: Path) -> None:
+    target = tmp_path / "agent.yaml"
+    target.write_text("tools:\n  - name: lookup\n    description: Get data\n", encoding="utf-8")
+
+    output = _run_hook(target)
+
+    specific = output["hookSpecificOutput"]
+    assert specific["hookEventName"] == "AfterTool"
+    assert "agent.yaml" in specific["additionalContext"]
+    assert "Suggested repair:" in specific["additionalContext"]
+    assert "evidence" not in specific["additionalContext"].lower()
+
+
+def test_after_tool_is_silent_for_unsupported_file(tmp_path: Path) -> None:
+    target = tmp_path / "module.js"
+    target.write_text("export const value = 1;\n", encoding="utf-8")
+
+    assert _run_hook(target, tool_name="write_file") == {}
+
+
+def test_after_tool_is_silent_when_tool_failed(tmp_path: Path) -> None:
+    target = tmp_path / "agent.yaml"
+    target.write_text("tools: []\n", encoding="utf-8")
+
+    assert _run_hook(target, error="write failed") == {}


### PR DESCRIPTION
## Summary
- package LintLang as a native Gemini CLI extension
- scan successful write_file and replace edits with a bounded AfterTool hook
- bundle repository source and pin the only runtime dependency via uv
- document installation and the non-blocking repair contract

## Validation
- Gemini CLI 0.32.1 strict extension validation
- copied-install live Gemini run observed one real write_file and surfaced LintLang findings
- Hermes Gate full: Ruff plus 405 tests and 76 subtests
- Roli Twin: PASS (ship locally)
