### PR TITLE
Add native OpenCode repair adapter

### DIFF
--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -1,0 +1,39 @@
+# LintLang for OpenCode
+
+This native OpenCode plugin runs LintLang after successful file-edit tools and
+appends concise repair context to the tool result. It supports OpenCode
+`1.18.27` and the legacy plugin contract `tool.execute.after`. The adapter
+never rewrites files or blocks a tool call.
+
+## Install
+
+Install the pinned LintLang release so `lintlang` is on `PATH`:
+
+```bash
+pipx install lintlang==0.5.2
+```
+
+Copy `lintlang.js` into `.opencode/plugins/` (project-local) or
+`~/.config/opencode/plugins/` (global). Start OpenCode in the project as usual.
+
+## Behavior and limits
+
+The plugin handles `edit`, `multiedit`, `patch`, `write`, and `apply_patch` when
+the post-tool args or metadata identify an explicit `filePath`, `file_path`,
+`path`, `file`, or `files` entry. It scans `.yaml`, `.yml`, `.json`, `.txt`,
+`.md`, `.prompt`, and `.py`, returning at most eight findings and omitting raw
+evidence. Tools without an explicit path (for example a patch whose target is
+only embedded in patch text) are skipped because the host does not provide a
+reliable changed-file list through this contract.
+
+OpenCode `1.18.27` was verified from the published `@opencode-ai/plugin@1.18.27`
+type declarations: `tool.execute.after` receives tool name/args and output
+metadata. `file.edited` is not present in that pinned declaration, so this
+adapter does not claim support for it. Newer OpenCode releases may expose a
+different event API; validate the installed host before upgrading this adapter.
+
+## Local smoke test
+
+```bash
+opencode --version                 # expected: 1.18.27 for the tested host
+```

--- a/integrations/opencode/lintlang.js
+++ b/integrations/opencode/lintlang.js
@@ -1,0 +1,72 @@
+/** OpenCode 1.x post-tool adapter for LintLang. */
+
+const SUPPORTED_SUFFIXES = new Set([".json", ".md", ".prompt", ".py", ".txt", ".yaml", ".yml"])
+const EDIT_TOOLS = new Set(["edit", "multiedit", "patch", "write", "apply_patch"])
+const MAX_FINDINGS = 8
+const PINNED_VERSION = "0.5.2"
+
+function pathsFrom(value) {
+  if (!value || typeof value !== "object") return []
+  const paths = []
+  for (const key of ["filePath", "file_path", "path", "file"]) {
+    if (typeof value[key] === "string") paths.push(value[key])
+  }
+  if (Array.isArray(value.files)) {
+    for (const file of value.files) if (typeof file === "string") paths.push(file)
+  }
+  return paths
+}
+
+function candidatePaths(input, output) {
+  return [...new Set([...pathsFrom(input.args), ...pathsFrom(output.metadata)])]
+}
+
+function formatResult(path, result) {
+  if (result.input_error) return `LintLang could not scan ${path}: ${result.input_error}`
+  const findings = result.structural_findings || []
+  if (!findings.length) return ""
+  const lines = [
+    `LintLang found ${findings.length} issue(s) in ${path} (verdict: ${result.verdict || "unknown"}).`,
+    "Repair the applicable findings, then keep the user's requested behavior intact:",
+  ]
+  for (const finding of findings.slice(0, MAX_FINDINGS)) {
+    const code = finding.code || finding.pattern_id || "LintLang"
+    const severity = String(finding.severity || "unknown").toUpperCase()
+    let line = `- [${severity} ${code}] ${finding.location || "file"}: ${finding.description || "Issue detected."}`
+    if (finding.suggestion) line += ` Suggested repair: ${finding.suggestion}`
+    lines.push(line)
+  }
+  if (findings.length > MAX_FINDINGS) lines.push(`- ${findings.length - MAX_FINDINGS} additional finding(s) omitted; run \`lintlang scan -- ${path}\` for all details.`)
+  return lines.join("\n")
+}
+
+async function scan(ctx, path) {
+  const command = `lintlang scan --format json -- ${path}`
+  try {
+    const result = await ctx.$`lintlang --version`.quiet().nothrow().text()
+    if (result.trim() !== `lintlang ${PINNED_VERSION}`) {
+      return `LintLang could not check ${path} because lintlang ${PINNED_VERSION} is not available. Install it with \`pipx install lintlang==${PINNED_VERSION}\`.`
+    }
+    const output = await ctx.$`lintlang scan --format json -- ${path}`.quiet().nothrow().text()
+    const parsed = JSON.parse(output)
+    if (!Array.isArray(parsed) || !parsed[0]) throw new Error("LintLang returned no file result")
+    return formatResult(path, parsed[0])
+  } catch (error) {
+    return `LintLang could not check ${path}: ${error instanceof Error ? error.message : String(error)}. Run \`${command}\` directly for diagnostics.`
+  }
+}
+
+export const LintLang = async (ctx) => ({
+  "tool.execute.after": async (input, output) => {
+    if (!EDIT_TOOLS.has(input.tool)) return
+    const paths = candidatePaths(input, output)
+    for (const rawPath of paths) {
+      const path = String(rawPath)
+      if (!SUPPORTED_SUFFIXES.has(path.slice(path.lastIndexOf(".")).toLowerCase())) continue
+      const context = await scan(ctx, path)
+      if (context) output.output = `${output.output || ""}\n\n${context}`.trim()
+    }
+  },
+})
+
+export default LintLang

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_opencode_adapter_is_bounded_and_documents_contract():
+    plugin = (ROOT / "integrations/opencode/lintlang.js").read_text()
+    docs = (ROOT / "integrations/opencode/README.md").read_text()
+    assert '"tool.execute.after"' in plugin
+    assert "MAX_FINDINGS = 8" in plugin
+    assert "file.edited" in docs
+    assert "explicit path" in docs
+    assert "raw" in docs and "evidence" in docs


### PR DESCRIPTION
## Summary
- add a native OpenCode 1.18.27 `tool.execute.after` adapter
- append bounded LintLang repair context only when tool args or metadata expose an explicit changed-file path
- pin the supported LintLang release and document skipped patch tools rather than claiming the absent `file.edited` hook

## Validation
- official `@opencode-ai/plugin@1.18.27` declaration inspected (`tool.execute.after` present; `file.edited` absent)
- real OpenCode 1.18.27 host startup succeeded
- Node hook smoke passed
- Hermes Gate full: Ruff plus 408 tests and 76 subtests
- Roli Twin: Ship it
