### PR TITLE
Add AI_LINTLANG MegaLinter plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- External MegaLinter plugin exposing the pinned LintLang scanner as
+  `AI_LINTLANG`, with an exact configuration guide and clean/failing fixture
+  coverage.
+
 ## [0.5.3] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 - External MegaLinter plugin exposing the pinned LintLang scanner as
   `AI_LINTLANG`, with an exact configuration guide and clean/failing fixture
-  coverage.
+  coverage. Verified end to end in `oxsecurity/megalinter-python:v9.4.0`: the
+  descriptor loads, `lintlang==0.5.3` installs at run time, a failing fixture
+  exits 1, and a clean-only workspace exits 0.
 
 ## [0.5.3] - 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -254,10 +254,11 @@ Missing, unreadable, or malformed configured inputs still return nonzero.
 
 ## Use it with MegaLinter
 
-The external MegaLinter plugin exposes LintLang as `AI_LINTLANG`, with the
-released package pinned in the generated MegaLinter image. See the
+The external MegaLinter plugin exposes LintLang as `AI_LINTLANG`, installing the
+pinned release at run time through MegaLinter's plugin loader. See the
 [MegaLinter plugin guide](mega-linter-plugin-lintlang/README.md) for the exact
-`PLUGINS` and `ENABLE_LINTERS` configuration.
+`PLUGINS` and `ENABLE_LINTERS` configuration and the container verification
+steps.
 
 ## Use it with Gemini CLI
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,13 @@ hooks:
 
 Missing, unreadable, or malformed configured inputs still return nonzero.
 
+## Use it with MegaLinter
+
+The external MegaLinter plugin exposes LintLang as `AI_LINTLANG`, with the
+released package pinned in the generated MegaLinter image. See the
+[MegaLinter plugin guide](mega-linter-plugin-lintlang/README.md) for the exact
+`PLUGINS` and `ENABLE_LINTERS` configuration.
+
 ## Use it with Gemini CLI
 
 The repository root is also a Gemini CLI extension. Its non-blocking

--- a/mega-linter-plugin-lintlang/README.md
+++ b/mega-linter-plugin-lintlang/README.md
@@ -23,10 +23,12 @@ PLUGINS:
   - file://mega-linter-plugin-lintlang/lintlang.megalinter-descriptor.yml
 ```
 
-MegaLinter installs the pinned LintLang release and runs the equivalent of:
+MegaLinter's plugin loader runs the descriptor's `install` step at run time
+(`pip install --no-cache-dir lintlang==0.5.3`) inside the existing MegaLinter
+image, then invokes:
 
 ```console
-lintlang scan <selected files> --fail-on fail
+lintlang scan --fail-on fail <selected files>
 ```
 
 A LintLang `FAIL` verdict makes the linter exit nonzero. `REVIEW` remains
@@ -44,4 +46,53 @@ python -m pytest -q tests/test_megalinter_plugin.py
 
 The test validates the descriptor contract and proves that the descriptor's
 arguments pass `samples/clean_config.yaml` while failing
-`samples/bad_tool_descriptions.yaml`.
+`samples/bad_tool_descriptions.yaml`. It exercises the CLI in-process; it does
+not exercise MegaLinter's loader.
+
+## Verify against a real MegaLinter container
+
+The checks above are in-process. To prove the loader, the run-time install, and
+the exit code, run the plugin inside a real MegaLinter image.
+
+Build a scratch workspace containing `.mega-linter.yml`, this plugin directory,
+and two fixtures copied from `samples/` — `agent-clean.yaml`
+(`clean_config.yaml`) and `agent-bad.yaml` (`bad_tool_descriptions.yaml`):
+
+```yaml
+# .mega-linter.yml
+PLUGINS:
+  - file://mega-linter-plugin-lintlang/lintlang.megalinter-descriptor.yml
+ENABLE_LINTERS:
+  - AI_LINTLANG
+VALIDATE_ALL_CODEBASE: true
+LOG_LEVEL: INFO
+```
+
+```console
+docker run --rm --platform linux/amd64 \
+  -v "$PWD:/tmp/lint:rw" -e DEFAULT_WORKSPACE=/tmp/lint \
+  oxsecurity/megalinter-python:v9.4.0
+```
+
+Observed on `oxsecurity/megalinter-python:v9.4.0`
+(digest `sha256:e83df3697c0547024b3a21938f19125564627d86a1ffe6f6a18747c0dfd80d69`):
+
+- `[Plugins] Successful initialization of AI plugins`
+- `- Using [lintlang v0.5.3] https://lintlang.ai/`
+- `- Command: [lintlang scan --fail-on fail .mega-linter.yml agent-bad.yaml
+  agent-clean.yaml mega-linter-plugin-lintlang/lintlang.megalinter-descriptor.yml]`
+- `agent-bad.yaml` → `FAIL` (1 critical, 2 high, 7 medium, 3 low);
+  `agent-clean.yaml` → `PASS`
+- MegaLinter reported `1` error and exited **1**
+
+Removing `agent-bad.yaml` and rerunning the same command yields
+`Successfully linted all files without errors` and exit **0**, confirming the
+nonzero exit is caused by the LintLang `FAIL` verdict and not by the plugin
+load or install path.
+
+The descriptor also validates against MegaLinter's published
+[descriptor JSON schema](https://github.com/oxsecurity/megalinter/blob/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json).
+
+MegaLinter passes every matching file to LintLang, including `.mega-linter.yml`
+and this descriptor. Both scan clean; use `FILTER_REGEX_EXCLUDE` if you prefer
+to keep them out of the file list.

--- a/mega-linter-plugin-lintlang/README.md
+++ b/mega-linter-plugin-lintlang/README.md
@@ -1,0 +1,47 @@
+# LintLang for MegaLinter
+
+This external plugin adds `AI_LINTLANG` to MegaLinter. It scans agent
+instructions, tool definitions, prompts, and Python files containing embedded
+agent language. The plugin is deterministic and makes no LLM calls.
+
+## Configure
+
+Add the descriptor URL and enable the linter in `.mega-linter.yml`:
+
+```yaml
+PLUGINS:
+  - https://raw.githubusercontent.com/hermes-labs-ai/lintlang/main/mega-linter-plugin-lintlang/lintlang.megalinter-descriptor.yml
+
+ENABLE_LINTERS:
+  - AI_LINTLANG
+```
+
+For a local checkout, replace the HTTPS URL with:
+
+```yaml
+PLUGINS:
+  - file://mega-linter-plugin-lintlang/lintlang.megalinter-descriptor.yml
+```
+
+MegaLinter installs the pinned LintLang release and runs the equivalent of:
+
+```console
+lintlang scan <selected files> --fail-on fail
+```
+
+A LintLang `FAIL` verdict makes the linter exit nonzero. `REVIEW` remains
+advisory. MegaLinter's normal file filtering and exclusion settings determine
+which `.json`, `.md`, `.py`, `.txt`, `.yaml`, and `.yml` files are passed to
+LintLang.
+
+## Verify locally
+
+From the LintLang repository root:
+
+```console
+python -m pytest -q tests/test_megalinter_plugin.py
+```
+
+The test validates the descriptor contract and proves that the descriptor's
+arguments pass `samples/clean_config.yaml` while failing
+`samples/bad_tool_descriptions.yaml`.

--- a/mega-linter-plugin-lintlang/README.md
+++ b/mega-linter-plugin-lintlang/README.md
@@ -90,6 +90,15 @@ Removing `agent-bad.yaml` and rerunning the same command yields
 nonzero exit is caused by the LintLang `FAIL` verdict and not by the plugin
 load or install path.
 
+The same descriptor was also exercised in the full `oxsecurity/megalinter:v8`
+image (MegaLinter 8.8.0) with `docker run --rm -v "$PWD:/tmp/lint"
+oxsecurity/megalinter:v8`, adding unrelated `README.md`, `notes.txt`,
+`package.json`, and `src/app.py` files to the workspace. The plugin loader
+reported `[Plugins] Install command: pip install --no-cache-dir
+lintlang==0.5.3`, the version probe returned `lintlang 0.5.3`, only the bad
+fixture produced `FAIL`, the unrelated files passed clean, MegaLinter counted
+one error, and the container exited 1; without the bad fixture it exited 0.
+
 The descriptor also validates against MegaLinter's published
 [descriptor JSON schema](https://github.com/oxsecurity/megalinter/blob/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json).
 

--- a/mega-linter-plugin-lintlang/lintlang.megalinter-descriptor.yml
+++ b/mega-linter-plugin-lintlang/lintlang.megalinter-descriptor.yml
@@ -1,0 +1,31 @@
+descriptor_id: AI
+descriptor_type: other
+descriptor_flavors:
+  - all_flavors
+file_extensions:
+  - ".json"
+  - ".md"
+  - ".py"
+  - ".txt"
+  - ".yaml"
+  - ".yml"
+linters:
+  - linter_name: lintlang
+    name: AI_LINTLANG
+    linter_url: https://lintlang.ai/
+    linter_repo: https://github.com/hermes-labs-ai/lintlang
+    cli_lint_mode: list_of_files
+    supported_cli_lint_modes:
+      - list_of_files
+    cli_lint_extra_args:
+      - scan
+      - --fail-on
+      - fail
+    cli_help_arg_name: --help
+    cli_version_arg_name: --version
+    examples:
+      - lintlang scan AGENTS.md --fail-on fail
+      - lintlang scan agent.yaml tools.json --fail-on fail
+    install:
+      dockerfile:
+        - RUN pip install --no-cache-dir lintlang==0.5.3

--- a/tests/test_megalinter_plugin.py
+++ b/tests/test_megalinter_plugin.py
@@ -51,3 +51,44 @@ def test_megalinter_invocation_passes_clean_and_fails_bad_fixture() -> None:
 
     assert main([*prefix, str(ROOT / "samples" / "clean_config.yaml")]) == 0
     assert main([*prefix, str(ROOT / "samples" / "bad_tool_descriptions.yaml")]) == 1
+
+
+def test_megalinter_list_of_files_batch_fails_only_on_known_finding(
+    tmp_path: Path,
+) -> None:
+    """Mirror the real ``oxsecurity/megalinter-python:v9.4.0`` list_of_files call.
+
+    MegaLinter passes every kept file in one command:
+    ``lintlang scan --fail-on fail <file> <file> ...``. The batch must exit 1
+    when exactly one file carries a known FAIL verdict, and exit 0 once that
+    file is removed, without unrelated ``.md``/``.py``/``.txt``/``.json``
+    files producing findings.
+    """
+    linter = _descriptor()["linters"][0]
+    prefix = linter["cli_lint_extra_args"]
+
+    bad = tmp_path / "bad_tool_descriptions.yaml"
+    bad.write_text(
+        (ROOT / "samples" / "bad_tool_descriptions.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    clean = tmp_path / "clean_config.yaml"
+    clean.write_text(
+        (ROOT / "samples" / "clean_config.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    unrelated = [
+        tmp_path / "README.md",
+        tmp_path / "notes.txt",
+        tmp_path / "package.json",
+        tmp_path / "app.py",
+    ]
+    unrelated[0].write_text("# Fixture\n\nOrdinary readme text.\n", encoding="utf-8")
+    unrelated[1].write_text("plain notes, nothing prompt-like\n", encoding="utf-8")
+    unrelated[2].write_text('{"name": "demo", "version": 1}\n', encoding="utf-8")
+    unrelated[3].write_text("def add(a: int, b: int) -> int:\n    return a + b\n", encoding="utf-8")
+
+    batch = [str(clean), *(str(path) for path in unrelated)]
+
+    assert main([*prefix, str(bad), *batch]) == 1
+    assert main([*prefix, *batch]) == 0

--- a/tests/test_megalinter_plugin.py
+++ b/tests/test_megalinter_plugin.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from lintlang.cli import main
+
+ROOT = Path(__file__).resolve().parents[1]
+DESCRIPTOR = (
+    ROOT
+    / "mega-linter-plugin-lintlang"
+    / "lintlang.megalinter-descriptor.yml"
+)
+
+
+def _descriptor() -> dict:
+    return yaml.safe_load(DESCRIPTOR.read_text(encoding="utf-8"))
+
+
+def test_megalinter_descriptor_contract() -> None:
+    descriptor = _descriptor()
+
+    assert descriptor["descriptor_id"] == "AI"
+    assert descriptor["descriptor_type"] == "other"
+    assert descriptor["descriptor_flavors"] == ["all_flavors"]
+    assert set(descriptor["file_extensions"]) == {
+        ".json",
+        ".md",
+        ".py",
+        ".txt",
+        ".yaml",
+        ".yml",
+    }
+
+    assert len(descriptor["linters"]) == 1
+    linter = descriptor["linters"][0]
+    assert linter["linter_name"] == "lintlang"
+    assert linter["name"] == "AI_LINTLANG"
+    assert linter["cli_lint_mode"] == "list_of_files"
+    assert linter["supported_cli_lint_modes"] == ["list_of_files"]
+    assert linter["cli_lint_extra_args"] == ["scan", "--fail-on", "fail"]
+    assert linter["install"]["dockerfile"] == [
+        "RUN pip install --no-cache-dir lintlang==0.5.3"
+    ]
+
+
+def test_megalinter_invocation_passes_clean_and_fails_bad_fixture() -> None:
+    linter = _descriptor()["linters"][0]
+    prefix = linter["cli_lint_extra_args"]
+
+    assert main([*prefix, str(ROOT / "samples" / "clean_config.yaml")]) == 0
+    assert main([*prefix, str(ROOT / "samples" / "bad_tool_descriptions.yaml")]) == 1


### PR DESCRIPTION
## Summary

Adds an external MegaLinter plugin, `AI_LINTLANG`, under `mega-linter-plugin-lintlang/`.

- `lintlang.megalinter-descriptor.yml`: descriptor for the `AI` descriptor id, `list_of_files` mode, `lintlang scan --fail-on fail <files>`, run-time install of `lintlang==0.5.3`.
- `README.md` for the plugin: configuration, local verification, and container verification steps.
- `tests/test_megalinter_plugin.py`: validates the descriptor contract and proves the descriptor arguments pass `samples/clean_config.yaml` and fail `samples/bad_tool_descriptions.yaml`.
- README and CHANGELOG entries.

## Verification

- Loader, run-time install, and exit code proven in `oxsecurity/megalinter-python:v9.4.0` and in the full `oxsecurity/megalinter:v8` image: failing fixture exits 1, clean workspace exits 0.
- Descriptor validates against MegaLinter's published descriptor JSON schema.
- Local gate at 117939c: `ruff check`, `pytest`, and `lintlang scan samples/clean_config.yaml` pass.

Follow-up: catalog row in oxsecurity/megalinter (`.automation/plugins.yml`) and reply on oxsecurity/megalinter#8865 once the raw descriptor URL resolves from `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MegaLinter integration through the `AI_LINTLANG` linter plugin.
  * Supports scanning JSON, Markdown, Python, text, and YAML files.
  * Configured scans report failing findings as errors while advisory reviews remain non-blocking.
  * Uses a pinned LintLang version for consistent results.

* **Documentation**
  * Added setup, configuration, installation, and usage guidance.
  * Documented verification steps using MegaLinter containers.

* **Tests**
  * Added coverage for plugin configuration, clean scans, failing fixtures, and batch execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->