### PR TITLE
docs: foreground native agent instruction gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ lintlang scan AGENTS.md
 If your project uses another filename, replace `AGENTS.md` with its prompt,
 tool-definition, agent-configuration, or supported directory path.
 
+## Lint the instructions your coding agent actually reads
+
+LintLang treats agent instruction files as ordinary local inputs. It does not
+need a vendor API, an always-running agent hook, or a separate integration for
+each host.
+
+| Coding-agent workflow | Native instruction surface | Local gate | Generate CI/SARIF gate |
+| --- | --- | --- | --- |
+| Codex | `AGENTS.md` | `lintlang scan AGENTS.md` | `lintlang init --github --path AGENTS.md` |
+| Claude Code | `CLAUDE.md` | `lintlang scan CLAUDE.md` | `lintlang init --github --path CLAUDE.md` |
+| GitHub Copilot | `.github/copilot-instructions.md` or `.github/instructions/` | `lintlang scan .github/copilot-instructions.md` | `lintlang init --github --path .github/copilot-instructions.md` |
+| Gemini CLI | `GEMINI.md` | `lintlang scan GEMINI.md` | `lintlang init --github --path GEMINI.md` |
+
+For a repository that has exactly one of these common paths, `lintlang init
+--github` detects it automatically. Pass `--path` when the repository has
+more than one instruction surface or when you want to scan an instruction
+directory. The generated workflow runs the same local scanner and uploads
+SARIF; it does not change how the coding agent loads its instructions.
+
 [Character.AI's public Larch repository](https://github.com/character-ai/larch/blob/ef7ee4b7f946f29fa51981f5422a1a93e83c79a7/.github/workflows/requirements-agent-linters.txt)
 pins `lintlang==0.3.1` in recurring CI. LintLang also has independent Gentoo
 packaging in the unofficial
@@ -156,9 +175,9 @@ the highest-severity findings.
 
 ## Add it to CI
 
-From a Git repository containing `AGENTS.md`, `CLAUDE.md`, a Copilot
-instructions file, or an agent YAML/JSON config, create the pinned GitHub Code
-Scanning workflow in one command:
+From a Git repository containing `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, a
+Copilot instructions file or directory, or an agent YAML/JSON config, create
+the pinned GitHub Code Scanning workflow in one command:
 
 ```bash
 lintlang init --github

--- a/src/lintlang/github_init.py
+++ b/src/lintlang/github_init.py
@@ -12,6 +12,8 @@ _DEFAULT_INPUTS = (
     Path("AGENTS.md"),
     Path("CLAUDE.md"),
     Path(".github/copilot-instructions.md"),
+    Path(".github/instructions"),
+    Path("GEMINI.md"),
     Path("agent.yaml"),
     Path("agent.yml"),
     Path("agent.json"),

--- a/tests/test_github_init.py
+++ b/tests/test_github_init.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from lintlang.cli import main
@@ -97,6 +98,36 @@ def test_init_github_is_idempotent(tmp_path, monkeypatch, capsys):
 
     assert (root / ".github/workflows/lintlang.yml").read_bytes() == first
     assert "Up to date" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "instruction_path",
+    (
+        "CLAUDE.md",
+        ".github/copilot-instructions.md",
+        ".github/instructions",
+        "GEMINI.md",
+    ),
+)
+def test_init_github_detects_common_coding_agent_instruction_paths(
+    tmp_path, monkeypatch, instruction_path
+):
+    root = tmp_path / "repository"
+    root.mkdir()
+    (root / ".git").mkdir()
+    target = root / instruction_path
+    if target.suffix:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# Instructions\n", encoding="utf-8")
+    else:
+        target.mkdir(parents=True)
+        (target / "review.instructions.md").write_text("# Instructions\n", encoding="utf-8")
+    monkeypatch.chdir(root)
+
+    assert main(["init", "--github"]) == 0
+
+    text = (root / ".github/workflows/lintlang.yml").read_text(encoding="utf-8")
+    assert f'path: "{instruction_path}"' in text
 
 
 def test_init_github_refuses_to_overwrite_without_force(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- make Codex, Claude Code, GitHub Copilot, and Gemini CLI ordinary LintLang file/CI workflows in the README
- let lintlang init --github auto-detect Copilot instruction directories and GEMINI.md
- add coverage for the common instruction paths

## Validation
- python -m pytest -q (415 passed, 76 subtests passed)
- ruff check src tests
- pre-commit try-repo . lintlang --files AGENTS.md --verbose

This intentionally uses the existing deterministic scanner and generated GitHub/SARIF workflow; it adds no agent-specific runtime dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GitHub Actions setup now automatically detects additional coding-agent instruction sources, including Gemini and GitHub Copilot instruction paths.
  - Generated workflows preserve the detected instruction path for linting.

- **Documentation**
  - Added guidance for linting instructions used by Codex, Claude Code, GitHub Copilot, and Gemini CLI.
  - Documented native instruction locations, local scan commands, CI/SARIF setup, automatic detection, and path selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->