### PR TITLE
fix: scope megalinter to instruction surfaces

### DIFF
--- a/mega-linter-plugin-lintlang/README.md
+++ b/mega-linter-plugin-lintlang/README.md
@@ -32,9 +32,20 @@ lintlang scan --fail-on fail <selected files>
 ```
 
 A LintLang `FAIL` verdict makes the linter exit nonzero. `REVIEW` remains
-advisory. MegaLinter's normal file filtering and exclusion settings determine
-which `.json`, `.md`, `.py`, `.txt`, `.yaml`, and `.yml` files are passed to
-LintLang.
+advisory. By default, the descriptor selects conventional agent-language names
+(`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, Copilot `*.instructions.md`, and files
+whose names contain `agent`, `prompt`, `tool`, `skill`, `system`, or
+`instruction`) rather than every Markdown, YAML, JSON, or Python file.
+
+To deliberately broaden a repository's scope, configure MegaLinter's normal
+per-linter override with the file extensions you own:
+
+```yaml
+AI_LINTLANG_FILE_EXTENSIONS:
+  - .yaml
+  - .yml
+  - .json
+```
 
 ## Verify locally
 
@@ -102,6 +113,6 @@ one error, and the container exited 1; without the bad fixture it exited 0.
 The descriptor also validates against MegaLinter's published
 [descriptor JSON schema](https://github.com/oxsecurity/megalinter/blob/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json).
 
-MegaLinter passes every matching file to LintLang, including `.mega-linter.yml`
-and this descriptor. Both scan clean; use `FILTER_REGEX_EXCLUDE` if you prefer
-to keep them out of the file list.
+MegaLinter passes every matching file to LintLang. Use its normal
+`FILTER_REGEX_EXCLUDE` or `AI_LINTLANG_FILE_NAMES_REGEX` controls when a
+repository needs a still narrower or differently named scope.

--- a/mega-linter-plugin-lintlang/lintlang.megalinter-descriptor.yml
+++ b/mega-linter-plugin-lintlang/lintlang.megalinter-descriptor.yml
@@ -2,13 +2,11 @@ descriptor_id: AI
 descriptor_type: other
 descriptor_flavors:
   - all_flavors
-file_extensions:
-  - ".json"
-  - ".md"
-  - ".py"
-  - ".txt"
-  - ".yaml"
-  - ".yml"
+# Keep the default scope to files that conventionally carry agent language.
+# Consumers can set AI_LINTLANG_FILE_EXTENSIONS to deliberately broaden it.
+file_names_regex:
+  - "(?i:(AGENTS|CLAUDE|GEMINI)\\.md)"
+  - "(?i:.*(agent|agents|prompt|prompts|tool|tools|skill|skills|system|instruction|instructions).*\\.(json|md|prompt|py|txt|yaml|yml))"
 linters:
   - linter_name: lintlang
     name: AI_LINTLANG

--- a/tests/test_megalinter_plugin.py
+++ b/tests/test_megalinter_plugin.py
@@ -24,14 +24,11 @@ def test_megalinter_descriptor_contract() -> None:
     assert descriptor["descriptor_id"] == "AI"
     assert descriptor["descriptor_type"] == "other"
     assert descriptor["descriptor_flavors"] == ["all_flavors"]
-    assert set(descriptor["file_extensions"]) == {
-        ".json",
-        ".md",
-        ".py",
-        ".txt",
-        ".yaml",
-        ".yml",
-    }
+    assert "file_extensions" not in descriptor
+    assert descriptor["file_names_regex"] == [
+        r"(?i:(AGENTS|CLAUDE|GEMINI)\.md)",
+        r"(?i:.*(agent|agents|prompt|prompts|tool|tools|skill|skills|system|instruction|instructions).*\.(json|md|prompt|py|txt|yaml|yml))",
+    ]
 
     assert len(descriptor["linters"]) == 1
     linter = descriptor["linters"][0]


### PR DESCRIPTION
## Summary
- narrow the external MegaLinter descriptor from every Markdown/YAML/JSON/Python file to conventional agent-instruction, prompt, skill, system, and tool filenames
- document the normal `AI_LINTLANG_FILE_EXTENSIONS` override for teams that intentionally want a broader scope
- retain the existing deterministic list-of-files contract

## Runtime evidence
- MegaLinter v8.8.0 loaded the plugin and installed lintlang 0.5.3
- failing fixture: selected AGENTS.md and bad-agent.yaml only, then exited nonzero for the expected CRITICAL/HIGH findings
- clean fixture: selected AGENTS.md only and exited 0

## Validation
- python -m pytest -q (415 passed, 76 subtests passed)
- ruff check src tests