### PR TITLE
fix: bound verified H2 loops with local checks

### DIFF
--- a/src/lintlang/patterns.py
+++ b/src/lintlang/patterns.py
@@ -760,6 +760,36 @@ DANGEROUS_PATTERNS = [
 ]
 
 
+_SUCCESS_CRITERIA_PREFIX = re.compile(
+    r"\b(?:define|set|state|establish)\s+(?:clear\s+)?success\s+criteria\s*\.\s*$",
+    re.IGNORECASE,
+)
+_VERIFICATION_GUIDANCE = re.compile(
+    r"\bverify\s*:\s*\S|\b(?:write|run|ensure)\s+(?:[\w-]+\s+){0,6}(?:tests?|checks?)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_bounded_verification_loop(text: str, match: re.Match[str]) -> bool:
+    """Recognize a documented verification loop with an explicit local exit.
+
+    ``loop until`` is usually an unsafe open-ended instruction.  The specific
+    ``Define success criteria. Loop until verified.`` form is different only
+    when the immediately surrounding guidance also names a concrete check.
+    Keep this deliberately narrow: it does not exempt retries, negative
+    termination, or a bare promise to define criteria.
+    """
+    if match.group().lower().split() != ["loop", "until"]:
+        return False
+
+    if not re.match(r"\s+verified\b", text[match.end() :], re.IGNORECASE):
+        return False
+
+    prefix = text[max(0, match.start() - 160) : match.start()]
+    guidance = text[match.end() : match.end() + 600]
+    return bool(_SUCCESS_CRITERIA_PREFIX.search(prefix) and _VERIFICATION_GUIDANCE.search(guidance))
+
+
 def detect_h2(config: AgentConfig) -> list[Finding]:
     """Detect missing constraint scaffolding."""
     findings: list[Finding] = []
@@ -795,6 +825,8 @@ def detect_h2(config: AgentConfig) -> list[Finding]:
         matches = list(re.finditer(pattern, text, re.IGNORECASE))
         for match in matches:
             if not _is_direct_match(scope, match.start(), match.end()):
+                continue
+            if _is_bounded_verification_loop(text, match):
                 continue
             start = max(0, match.start() - 20)
             end = min(len(text), match.end() + 40)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -460,6 +460,28 @@ class TestH2:
         findings = detect_h2(config)
         assert any(f.severity == Severity.CRITICAL for f in findings)
 
+    def test_bounded_verification_loop_with_explicit_criteria_and_checks(self):
+        """A verification loop is bounded when its local exit is concrete."""
+        config = AgentConfig(
+            system_prompt=(
+                "## Goal-Driven Execution\n\n"
+                "Define success criteria. Loop until verified.\n\n"
+                "Transform tasks into verifiable goals: write tests for invalid inputs, "
+                "then make them pass.\n"
+            )
+        )
+
+        assert not any(f.severity == Severity.CRITICAL for f in detect_h2(config))
+
+    def test_bare_or_retry_loop_remains_critical_despite_success_criteria(self):
+        for prompt in (
+            "Define success criteria. Loop until verified.",
+            "Define success criteria. Loop until verified. Transform tasks into verifiable goals.",
+            "Define success criteria. Keep trying until it succeeds. Write tests and make them pass.",
+        ):
+            findings = detect_h2(AgentConfig(system_prompt=prompt))
+            assert any(f.severity == Severity.CRITICAL for f in findings)
+
     def test_missing_constraints_with_tools(self):
         config = AgentConfig(
             system_prompt="You are an assistant. Use the tools to help.",


### PR DESCRIPTION
## Summary
- avoid an H2 CRITICAL finding only for the narrow `Define success criteria. Loop until verified.` pattern when nearby guidance supplies a concrete test/check verification action
- retain CRITICAL findings for bare verified loops and retry-until-success wording
- add the real-world bounded-loop regression cases

## Why
A public instruction-file trial showed that this exact phrase can be bounded by explicit success criteria and concrete verification steps. Treating that narrow form as unconditionally unbounded would make an unsolicited downstream correction misleading.

## Validation
- pytest -q tests/test_patterns.py tests/test_scope_gated_detectors.py tests/test_quoted_example_regression.py (92 passed)
- ruff check src/lintlang/patterns.py tests/test_patterns.py