### PR TITLE
docs: show pre-commit CI invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,14 @@ pre-commit install
 pre-commit run lintlang
 ```
 
+In CI, after installing `pre-commit`, run that same configured hook across the
+repository:
+
+```yaml
+- name: Lint agent instructions
+  run: pre-commit run lintlang --all-files
+```
+
 Replace or extend `args` with the prompt, tool-definition, agent-configuration,
 or supported directory paths your repository owns. The hook scans only those
 configured paths and reports findings without blocking on a verdict by default.


### PR DESCRIPTION
Documents the native CI command for repositories that already configure LintLang as a pre-commit hook.

The example runs only the configured `lintlang` hook across the repository after `pre-commit` is installed; it does not introduce a new integration or configuration surface.

Validation: `pre-commit run --files README.md` and `git diff --check`.