### PR TITLE
fix: pin GitHub Action onboarding to v0.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ jobs:
           persist-credentials: false
 
       - name: Run LintLang
-        uses: hermes-labs-ai/lintlang@cad2dca3054b8bfb5d0a6b93ecf19f9d74ab64fe # v0.5.0
+        uses: hermes-labs-ai/lintlang@f89c3b0b8986fad162859dca052a8d5fe227eede # v0.5.3
         with:
           path: AGENTS.md
           fail-on: fail

--- a/examples/github-code-scanning.yml
+++ b/examples/github-code-scanning.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
 
       - name: Run LintLang
-        uses: hermes-labs-ai/lintlang@cad2dca3054b8bfb5d0a6b93ecf19f9d74ab64fe # v0.5.0
+        uses: hermes-labs-ai/lintlang@f89c3b0b8986fad162859dca052a8d5fe227eede # v0.5.3
         with:
           path: AGENTS.md
           fail-on: fail

--- a/src/lintlang/github_init.py
+++ b/src/lintlang/github_init.py
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: Scan agent instructions
-        uses: hermes-labs-ai/lintlang@cad2dca3054b8bfb5d0a6b93ecf19f9d74ab64fe # v0.5.0
+        uses: hermes-labs-ai/lintlang@f89c3b0b8986fad162859dca052a8d5fe227eede # v0.5.3
         with:
           path: __LINTLANG_INPUT__
           fail-on: fail

--- a/tests/test_code_scanning_example.py
+++ b/tests/test_code_scanning_example.py
@@ -9,7 +9,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLE_PATH = REPO_ROOT / "examples" / "github-code-scanning.yml"
-LINTLANG_V050_SHA = "cad2dca3054b8bfb5d0a6b93ecf19f9d74ab64fe"
+LINTLANG_V053_SHA = "f89c3b0b8986fad162859dca052a8d5fe227eede"
 UPLOAD_ARTIFACT_V7_SHA = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 DOWNLOAD_ARTIFACT_V8_SHA = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
 UPLOAD_SARIF_V4_SHA = "5595ccaf912efad79be6eef63a5619ff05969be3"
@@ -51,7 +51,7 @@ def test_code_scanning_example_is_least_privilege_and_uploads_even_after_failure
     download_step = next(step for step in upload["steps"] if step.get("name") == "Download LintLang SARIF")
     upload_step = next(step for step in upload["steps"] if step.get("name") == "Upload LintLang SARIF")
     assert checkout_step["with"]["persist-credentials"] is False
-    assert lintlang_step["uses"] == f"hermes-labs-ai/lintlang@{LINTLANG_V050_SHA}"
+    assert lintlang_step["uses"] == f"hermes-labs-ai/lintlang@{LINTLANG_V053_SHA}"
     assert lintlang_step["with"]["path"] == "AGENTS.md"
     assert lintlang_step["with"]["sarif-file"] == "lintlang.sarif"
     assert lintlang_step["with"]["fail-on"] == "fail"
@@ -64,7 +64,7 @@ def test_code_scanning_example_is_least_privilege_and_uploads_even_after_failure
     assert download_step["with"]["name"] == preserve_step["with"]["name"]
     assert upload_step["with"]["sarif_file"] == "lintlang.sarif"
     assert upload_step["uses"] == f"github/codeql-action/upload-sarif@{UPLOAD_SARIF_V4_SHA}"
-    assert f"lintlang@{LINTLANG_V050_SHA} # v0.5.0" in text
+    assert f"lintlang@{LINTLANG_V053_SHA} # v0.5.3" in text
     assert re.search(
         rf"github/codeql-action/upload-sarif@{UPLOAD_SARIF_V4_SHA}\s+# v4\b",
         text,
@@ -78,5 +78,5 @@ def test_readme_code_scanning_example_is_complete_and_matches_the_public_example
 
     assert match, "README Code Scanning section has no copy-paste YAML workflow"
     assert yaml.safe_load(match.group(1)) == yaml.safe_load(EXAMPLE_PATH.read_text(encoding="utf-8"))
-    assert f"lintlang@{LINTLANG_V050_SHA} # v0.5.0" in match.group(1)
+    assert f"lintlang@{LINTLANG_V053_SHA} # v0.5.3" in match.group(1)
     assert "pull_request_target" not in readme

--- a/tests/test_github_init.py
+++ b/tests/test_github_init.py
@@ -9,7 +9,7 @@ import yaml
 
 from lintlang.cli import main
 
-LINTLANG_V050_SHA = "cad2dca3054b8bfb5d0a6b93ecf19f9d74ab64fe"
+LINTLANG_V053_SHA = "f89c3b0b8986fad162859dca052a8d5fe227eede"
 UPLOAD_ARTIFACT_V7_SHA = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 DOWNLOAD_ARTIFACT_V8_SHA = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
 UPLOAD_SARIF_V4_SHA = "5595ccaf912efad79be6eef63a5619ff05969be3"
@@ -64,7 +64,7 @@ def test_init_github_creates_pinned_sarif_workflow(tmp_path, monkeypatch, capsys
     sarif_upload = next(step for step in upload["steps"] if step["name"] == "Upload SARIF")
 
     assert checkout["with"]["persist-credentials"] is False
-    assert lintlang["uses"] == f"hermes-labs-ai/lintlang@{LINTLANG_V050_SHA}"
+    assert lintlang["uses"] == f"hermes-labs-ai/lintlang@{LINTLANG_V053_SHA}"
     assert lintlang["with"] == {
         "path": "AGENTS.md",
         "fail-on": "fail",
@@ -83,7 +83,7 @@ def test_init_github_creates_pinned_sarif_workflow(tmp_path, monkeypatch, capsys
     assert download["with"]["name"] == preserve["with"]["name"]
     assert sarif_upload["uses"] == f"github/codeql-action/upload-sarif@{UPLOAD_SARIF_V4_SHA}"
     assert sarif_upload["with"]["sarif_file"] == preserve["with"]["path"]
-    assert f"lintlang@{LINTLANG_V050_SHA} # v0.5.0" in text
+    assert f"lintlang@{LINTLANG_V053_SHA} # v0.5.3" in text
     assert "Created: .github/workflows/lintlang.yml" in capsys.readouterr().out
 
 

--- a/tests/test_precommit_metadata.py
+++ b/tests/test_precommit_metadata.py
@@ -10,7 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 HOOKS = yaml.safe_load((REPO_ROOT / ".pre-commit-hooks.yaml").read_text(encoding="utf-8"))
 CHECKOUT_V7_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
 LINTLANG_ACTION_VERSION = "v0.5.3"
-LINTLANG_GENERATED_ACTION_SHA = "cad2dca3054b8bfb5d0a6b93ecf19f9d74ab64fe"
+LINTLANG_V053_SHA = "f89c3b0b8986fad162859dca052a8d5fe227eede"
 
 
 def test_precommit_hook_is_explicit_and_advisory_by_default():
@@ -48,5 +48,5 @@ def test_public_docs_show_exercised_install_and_hook_paths():
         assert "actions/checkout@v7" not in text
         assert "hermes-labs-ai/lintlang@v0.4.0" not in text
 
-    assert f"hermes-labs-ai/lintlang@{LINTLANG_GENERATED_ACTION_SHA} # v0.5.0" in code_scanning_example
+    assert f"hermes-labs-ai/lintlang@{LINTLANG_V053_SHA} # v0.5.3" in code_scanning_example
     assert f"hermes-labs-ai/lintlang@{LINTLANG_ACTION_VERSION}" not in code_scanning_example


### PR DESCRIPTION
Updates every official user-copyable LintLang Action reference to the verified v0.5.3 immutable tag. This keeps `lintlang init --github`, the README workflow, and the SARIF example aligned with the current release.

Validation:
- `uv run pytest tests/test_github_init.py tests/test_precommit_metadata.py tests/test_code_scanning_example.py` (16 passed)
- `uv run ruff check src/lintlang/github_init.py tests/test_github_init.py tests/test_precommit_metadata.py tests/test_code_scanning_example.py`
- `git diff --check`

Fresh independent review confirmed the diff contains only this action-pin/docs/test correction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated linting guidance for repository paths, severity thresholds, and Haven overlay release tracking.
  * Updated the GitHub Code Scanning example to reference LintLang v0.5.3.

* **Chores**
  * Updated generated GitHub Actions templates to use LintLang v0.5.3.
  * Pinned the action to an immutable commit for more reliable workflow execution.

* **Tests**
  * Updated validation checks to match the v0.5.3 action reference and version annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->