### PR TITLE
docs: cross-link third-party adoption attribution sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,16 @@ directory. The generated workflow runs the same local scanner and uploads
 SARIF; it does not change how the coding agent loads its instructions.
 
 [Character.AI's public Larch repository](https://github.com/character-ai/larch/blob/ef7ee4b7f946f29fa51981f5422a1a93e83c79a7/.github/workflows/requirements-agent-linters.txt)
-pins `lintlang==0.3.1` in recurring CI. LintLang also has independent Gentoo
-packaging in the unofficial
-[Haven overlay](https://github.com/thehaven/haven-overlay/tree/7754b33f332cd450784e9a0b69ec1bd997c20064/dev-util/lintlang), not the official tree or GURU.
+pins `lintlang==0.3.1` in recurring CI. Larch's
+[linting reference](https://github.com/character-ai/larch/blob/210d08a8f6c1b0dd14c27b709c66471bd31a5636/docs/linting.md)
+links this repository as the upstream and documents the gate: its consolidated
+`agent-lint` job scans `agents/`, `.claude/agents/`, `skills/`, and
+`.claude/skills/` and fails on HIGH or CRITICAL findings
+([merged July 2026](https://github.com/character-ai/larch/pull/7960)).
+LintLang also has independent Gentoo packaging in the unofficial
+[Haven overlay](https://github.com/thehaven/haven-overlay/tree/d052d950b05389fcd7c8f22939033319a5aec348/dev-util/lintlang),
+not the official tree or GURU; its ebuilds have tracked upstream releases since
+0.2.1, and its `metadata.xml` records this repository as the upstream remote.
 
 When you are ready to make `HIGH` or `CRITICAL` findings block CI:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -182,6 +182,11 @@ errors remain blocking.
 
 Exit codes: 0 = pass, 1 = findings matched --fail-on threshold or error.
 
+## Third-party adoption (public sources)
+
+- Character.AI's Larch repository pins `lintlang==0.3.1` in CI and fails on HIGH or CRITICAL findings; its linting reference links this repository as the upstream: https://github.com/character-ai/larch/blob/210d08a8f6c1b0dd14c27b709c66471bd31a5636/docs/linting.md (merged via https://github.com/character-ai/larch/pull/7960)
+- Independent Gentoo packaging in the unofficial Haven overlay, whose `metadata.xml` records this repository as the upstream remote: https://github.com/thehaven/haven-overlay/tree/d052d950b05389fcd7c8f22939033319a5aec348/dev-util/lintlang
+
 ## Part of Hermes Labs Ecosystem
 
 - little-canary: Prompt injection detection

--- a/llms.txt
+++ b/llms.txt
@@ -32,6 +32,11 @@ Key success condition:
 - the same input files produce the same verdict and structural findings with no network or model calls
 - the same preflight request produces byte-stable redacted output; unavailable coverage never becomes clean
 
+## Third-party adoption (public sources)
+
+- Character.AI's Larch repository pins `lintlang==0.3.1` in CI and fails on HIGH or CRITICAL findings; its linting reference links this repository as the upstream: https://github.com/character-ai/larch/blob/210d08a8f6c1b0dd14c27b709c66471bd31a5636/docs/linting.md (merged via https://github.com/character-ai/larch/pull/7960)
+- Independent Gentoo packaging in the unofficial Haven overlay, whose `metadata.xml` records this repository as the upstream remote: https://github.com/thehaven/haven-overlay/tree/d052d950b05389fcd7c8f22939033319a5aec348/dev-util/lintlang
+
 ## About Hermes Labs
 
 Hermes Labs is an independent AI-reliability lab building open-source tools that catch silent failure modes in production AI. More at [hermes-labs.ai](https://hermes-labs.ai).


### PR DESCRIPTION
Docs-only. Cross-links the durable third-party attribution sources for the two existing adoption claims, and surfaces them in `llms.txt` / `llms-full.txt`.

- Larch: the README previously linked only the pinned requirements file. Now also links Larch's `docs/linting.md` (which names this repository as upstream and documents the `agent-lint` gate) and merged PR character-ai/larch#7960 (2026-07-23).
- Haven overlay: refreshes the tree permalink to the current commit (ebuilds through 0.5.3) and notes that `metadata.xml` records this repository as the upstream remote.
- `llms.txt` and `llms-full.txt`: new "Third-party adoption (public sources)" section with the same two URLs.

Checks run: `tests/test_docs_consistency.py` + `tests/test_version_consistency.py` (7 passed), `scripts/sync-version-docs.py --version 0.5.3 --check` (exit 0), all cited URLs return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added linting reference details for Character.AI’s Larch repository.
  - Documented the consolidated lint job’s scanned locations and severity thresholds.
  - Updated Haven overlay information, including its upstream release tracking and repository metadata.
  - Added a “Third-party adoption” section covering public usage by Larch and Gentoo packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->