### PR TITLE
docs: give Gemini users a verified source install command

### DIFF
--- a/docs/gemini-cli-extension.md
+++ b/docs/gemini-cli-extension.md
@@ -14,16 +14,28 @@ the source bundled in the installed extension and asks uv for exactly
 ambient `lintlang` installation. The first scan may download that pinned wheel;
 later scans reuse uv's cache.
 
-From a checkout:
+From an already configured Gemini CLI, install the released 0.5.3 source:
+
+```bash
+gemini extensions install https://github.com/hermes-labs-ai/lintlang --ref=f89c3b0b8986fad162859dca052a8d5fe227eede
+gemini extensions list
+```
+
+Review the installation consent prompt. The source commit pins
+[v0.5.3](https://github.com/hermes-labs-ai/lintlang/releases/tag/v0.5.3).
+This command was verified with Gemini CLI 0.32.1; the extension list reports
+`lintlang (0.5.3)` as enabled, with `Type: git` and the source commit above.
+Restart an active Gemini CLI session to load the installed extension.
+
+Gemini CLI copies the extension, including `src/lintlang`, into its extension
+directory. No separate LintLang installation is required.
+
+For local development, install from a repository checkout instead:
 
 ```bash
 gemini extensions validate .
 gemini extensions install . --consent
 ```
-
-Once the root manifest is released, users can instead install the GitHub
-repository URL. Gemini CLI copies the extension, including `src/lintlang`, into
-its extension directory.
 
 ## Behavior
 


### PR DESCRIPTION
The Gemini extension guide still treated remote installation as a future capability and only showed installation from a local checkout. Add a working GitHub install command pinned to the released v0.5.3 source, an extension-list check, and a session-restart instruction.

The source-commit pin is intentional: on Gemini CLI 0.32.1, `--ref=v0.5.3` fails with a clone-destination error while the same released source installed by commit succeeds. The release-asset/workflow repair remains separate from this documentation change.

Validation: isolated `GEMINI_CLI_HOME` install with the documented source ref exited 0; `gemini extensions list` showed enabled `lintlang (0.5.3)`, `Type: git`, and the exact source ref. GitHub resolves v0.5.3 to that commit. `git diff --check` passed. Only the guide changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified installation instructions for released versions versus local development.
  - Added a pinned v0.5.3 GitHub commit command and verification guidance.
  - Documented consent prompts and session restart steps.
  - Clarified that a separate LintLang installation is not required.
  - Retained local checkout validation and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->