### PR TITLE
Allow teams to gate new findings with reviewed baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- Opt-in baselines for incremental adoption: `scan --write-baseline FILE`
+  records reviewed structural findings; `scan --baseline FILE` reports and
+  gates remaining findings. Exact repository-relative identities and occurrence
+  counts prevent file-wide or rule-wide suppression. Invalid inputs remain
+  fatal, and baseline creation refuses to overwrite existing paths.
+- Optional first-party GitHub Action `baseline` input for both terminal and
+  SARIF output, with protection against a SARIF report overwriting the baseline.
+  Reports disclose the acknowledged finding count; HERM scores are unchanged.
 - External MegaLinter plugin exposing the pinned LintLang scanner as
   `AI_LINTLANG`, with an exact configuration guide and clean/failing fixture
   coverage. Verified end to end in `oxsecurity/megalinter-python:v9.4.0`: the

--- a/README.md
+++ b/README.md
@@ -116,6 +116,28 @@ lintlang scan AGENTS.md --fail-on fail
 Each finding identifies the affected location, the detected pattern, its
 severity, and a suggested review action.
 
+### Adopt LintLang in an existing repository
+
+An existing instruction backlog does not have to delay a CI gate. The
+[baseline workflow](docs/baselines.md) records reviewed findings and lets the
+same scanner report and gate findings that are not acknowledged. It works in
+the CLI and the first-party GitHub Action, without disabling an entire rule.
+
+This feature is **unreleased**; use a source checkout containing this change.
+From the root of the project you want to scan:
+
+```bash
+# Review the full report before committing the generated baseline.
+lintlang scan AGENTS.md --write-baseline .lintlang-baseline.json
+
+# Keep the known backlog acknowledged while blocking new MEDIUM+ findings.
+lintlang scan AGENTS.md --baseline .lintlang-baseline.json --fail-on review
+```
+
+Baseline matching is exact and count-limited. Changed findings and findings in
+another file remain visible. Invalid inputs still fail; HERM scores are
+unchanged. See the guide for CI configuration, maintenance, and matching limits.
+
 ## Try the bundled example
 
 The source repository includes a deliberately broken example:

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: Verdict threshold that makes the action fail (fail or review).
     required: false
     default: fail
+  baseline:
+    description: Optional existing baseline file. Only unmatched findings affect the verdict; CI never creates a baseline.
+    required: false
+    default: ""
   python-version:
     description: Python version used to run LintLang.
     required: false
@@ -41,7 +45,13 @@ runs:
       env:
         LINTLANG_PATH: ${{ inputs.path }}
         LINTLANG_FAIL_ON: ${{ inputs.fail-on }}
-      run: lintlang scan "$LINTLANG_PATH" --fail-on "$LINTLANG_FAIL_ON"
+        LINTLANG_BASELINE: ${{ inputs.baseline }}
+      run: |
+        LINTLANG_ARGS=(scan "$LINTLANG_PATH" --fail-on "$LINTLANG_FAIL_ON")
+        if [ -n "$LINTLANG_BASELINE" ]; then
+          LINTLANG_ARGS+=(--baseline "$LINTLANG_BASELINE")
+        fi
+        lintlang "${LINTLANG_ARGS[@]}"
 
     - name: Scan agent instructions to SARIF
       if: inputs.sarif-file != ''
@@ -49,6 +59,7 @@ runs:
       env:
         LINTLANG_PATH: ${{ inputs.path }}
         LINTLANG_FAIL_ON: ${{ inputs.fail-on }}
+        LINTLANG_BASELINE: ${{ inputs.baseline }}
         LINTLANG_SARIF_FILE: ${{ inputs.sarif-file }}
       run: |
         LINTLANG_PATH_REAL="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$LINTLANG_PATH")"
@@ -56,6 +67,15 @@ runs:
         if [ "$LINTLANG_PATH_REAL" = "$LINTLANG_SARIF_REAL" ]; then
           echo "Error: inputs path and sarif-file must differ." >&2
           exit 1
+        fi
+        LINTLANG_ARGS=(scan "$LINTLANG_PATH" --format sarif --fail-on "$LINTLANG_FAIL_ON")
+        if [ -n "$LINTLANG_BASELINE" ]; then
+          LINTLANG_BASELINE_REAL="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$LINTLANG_BASELINE")"
+          if [ "$LINTLANG_BASELINE_REAL" = "$LINTLANG_SARIF_REAL" ]; then
+            echo "Error: inputs baseline and sarif-file must differ." >&2
+            exit 1
+          fi
+          LINTLANG_ARGS+=(--baseline "$LINTLANG_BASELINE")
         fi
         if [ -d "$LINTLANG_SARIF_FILE" ]; then
           echo "Error: sarif-file must name a file, not a directory." >&2
@@ -65,7 +85,7 @@ runs:
         LINTLANG_SARIF_TMP="$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/lintlang-sarif.XXXXXX")"
         trap 'rm -f -- "$LINTLANG_SARIF_TMP"' EXIT
         LINTLANG_STATUS=0
-        lintlang scan "$LINTLANG_PATH" --format sarif --fail-on "$LINTLANG_FAIL_ON" > "$LINTLANG_SARIF_TMP" || LINTLANG_STATUS=$?
+        lintlang "${LINTLANG_ARGS[@]}" > "$LINTLANG_SARIF_TMP" || LINTLANG_STATUS=$?
         mv -- "$LINTLANG_SARIF_TMP" "$LINTLANG_SARIF_FILE"
         trap - EXIT
         exit "$LINTLANG_STATUS"

--- a/docs/baselines.md
+++ b/docs/baselines.md
@@ -4,10 +4,18 @@ Baselines acknowledge a reviewed set of existing structural findings. They let
 a repository enable a gate while its maintainers work through that backlog.
 The default scanner behavior is unchanged until you pass `--baseline`.
 
-**Availability:** this feature is unreleased. Install a source checkout that
-contains it with `python -m pip install /path/to/lintlang`, preferably in a
-virtual environment. The published `lintlang==0.5.3` package and `v0.5.3` Action
-do not support these options.
+**Availability:** this feature is unreleased. After this change is merged,
+install the development source, preferably in a virtual environment:
+
+```bash
+python -m pip install 'git+https://github.com/hermes-labs-ai/lintlang.git@main'
+```
+
+For reproducible installation, replace `main` with the full reviewed commit
+SHA. You can also install an existing checkout with
+`python -m pip install /path/to/lintlang`. The published `lintlang==0.5.3`
+package and `v0.5.3` Action do not support these options; source installations
+may report that same version until the next release.
 
 ## Start from a reviewed scan
 
@@ -89,6 +97,9 @@ change the baseline can acknowledge findings.
   description, and evidence. Matching is exact; there are no wildcards or
   rule-wide exemptions. A changed location, message, or evidence can reopen a
   finding, including after a detector upgrade. Suggestions are not identity.
+  Python source-path prefixes are normalized to the repository-relative path,
+  so absolute versus relative invocation paths do not change the fingerprint;
+  actual line spans and prompt locations remain part of the identity.
 - Additional occurrences beyond the recorded count remain visible. Repeating
   the same file through multiple CLI paths does not enlarge its allowance.
 - HERM scores, quality thresholds, and source input errors are unchanged.

--- a/docs/baselines.md
+++ b/docs/baselines.md
@@ -1,0 +1,123 @@
+# Baselines: adopt now, review the backlog deliberately
+
+Baselines acknowledge a reviewed set of existing structural findings. They let
+a repository enable a gate while its maintainers work through that backlog.
+The default scanner behavior is unchanged until you pass `--baseline`.
+
+**Availability:** this feature is unreleased. Install a source checkout that
+contains it with `python -m pip install /path/to/lintlang`, preferably in a
+virtual environment. The published `lintlang==0.5.3` package and `v0.5.3` Action
+do not support these options.
+
+## Start from a reviewed scan
+
+Run from your project's Git root. Replace `AGENTS.md` with the actual file or
+supported directory your team wants to gate:
+
+```bash
+lintlang scan AGENTS.md --write-baseline .lintlang-baseline.json
+```
+
+This prints the complete scan report and writes a new baseline. Review those
+findings and decide which backlog you are accepting before committing the
+file. Creation is explicit; it never overwrites an existing file, including a
+symlink, and writes nothing if an input fails or no input is scanned. As with a
+normal scan, findings only produce a nonzero exit when you also request
+`--fail-on` or `--fail-under`; omit those flags for the initial inventory.
+
+Then enable the gate:
+
+```bash
+lintlang scan AGENTS.md --baseline .lintlang-baseline.json --fail-on review
+```
+
+`--fail-on review` blocks remaining MEDIUM, HIGH, or CRITICAL findings.
+`--fail-on fail` blocks remaining HIGH or CRITICAL findings. An unchanged scan
+with all findings acknowledged passes either structural gate. A newly added
+file receives no allowance from another file's entries. Missing, malformed, or
+unsupported baselines and source input errors return a nonzero exit even when
+no severity gate is requested.
+
+Use the same scan paths, `--patterns`, `--min-severity`, and `--exclude` options
+when creating and applying a baseline. Filters run before baseline matching.
+Expanding the selected rules or severity range can reveal findings that were
+never acknowledged.
+
+## GitHub Action
+
+Use the optional `baseline` input with an Action commit that contains this
+feature. The Action installs the scanner from that same commit. After the
+change is merged, replace `<BASELINE_ENABLED_COMMIT_SHA>` below with its full
+reviewed commit SHA; `v0.5.3` cannot be used for this workflow.
+
+```yaml
+name: Lint agent instructions
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: hermes-labs-ai/lintlang@<BASELINE_ENABLED_COMMIT_SHA>
+        with:
+          path: AGENTS.md
+          baseline: .lintlang-baseline.json
+          fail-on: review
+```
+
+The same input works with `sarif-file`. Only remaining findings are emitted as
+SARIF results; the run's `properties.lintlangBaseline` contains the suppressed
+count and verdict scope. The Action rejects a SARIF destination that resolves
+to the baseline, including symlink aliases. For uploading SARIF, follow the
+[Code Scanning permission and upload guidance](../README.md#machine-readable-output-and-github-code-scanning).
+
+CI only reads the committed baseline. It never creates or updates one. Review
+baseline edits as carefully as changes to the CI gate itself: anyone who can
+change the baseline can acknowledge findings.
+
+## What is matched and what is preserved
+
+- Each entry identifies a repository-relative POSIX path, a SHA-256 finding
+  fingerprint, and an occurrence count. In a non-Git directory, the invocation
+  directory is the root. Inputs outside that root are rejected for baseline
+  matching. Run from the same project root in local and CI workflows.
+- The fingerprint includes the diagnostic code, severity, location,
+  description, and evidence. Matching is exact; there are no wildcards or
+  rule-wide exemptions. A changed location, message, or evidence can reopen a
+  finding, including after a detector upgrade. Suggestions are not identity.
+- Additional occurrences beyond the recorded count remain visible. Repeating
+  the same file through multiple CLI paths does not enlarge its allowance.
+- HERM scores, quality thresholds, and source input errors are unchanged.
+  Terminal and Markdown reports state that their verdict covers remaining
+  findings. JSON reports add `baseline.suppressed` to each scanned result.
+
+The baseline stores paths and hashes, not raw prompts or finding evidence.
+Hashes are not encryption: review filenames and the sensitivity of your inputs
+before publishing a baseline. Ordinary scan reports may still contain evidence.
+
+## Maintain a shrinking backlog
+
+After fixing findings, create a candidate at a new path and review it before
+replacing the committed baseline:
+
+```bash
+lintlang scan AGENTS.md --write-baseline .lintlang-baseline.candidate.json
+git diff --no-index .lintlang-baseline.json .lintlang-baseline.candidate.json
+# After review:
+mv .lintlang-baseline.candidate.json .lintlang-baseline.json
+```
+
+`git diff --no-index` exits 1 when the files differ; that is expected. Compare
+the complete scan report as well as the hash changes. Never refresh a baseline
+automatically after a failed gate: doing so can accept the very changes the
+gate was meant to surface.
+
+Unused entries are allowed, so removing a finding does not itself break CI.
+Prune them through the reviewed refresh above. An identical finding reintroduced
+at the same identity can still match an old entry until it is removed. A
+baseline records acknowledged identities, not the history of when each defect
+was fixed. It does not assess runtime agent behavior or establish safety.

--- a/src/lintlang/baseline.py
+++ b/src/lintlang/baseline.py
@@ -84,11 +84,18 @@ def _source_path(source: str, root: Path) -> str:
     return relative
 
 
-def _fingerprint(finding: Finding) -> str:
+def _fingerprint(finding: Finding, source: str, relative_path: str) -> str:
+    location = finding.location
+    # Python detectors prefix locations with the invocation's source path.
+    # Normalize only that exact prefix; keep line spans and prompt locations
+    # intact so source changes still reopen findings across portable checkouts.
+    prefix = f"{source}:"
+    if Path(source).suffix.lower() == ".py" and location.startswith(prefix):
+        location = f"{relative_path}:{location[len(prefix):]}"
     identity = {
         "code": finding.code,
         "severity": finding.severity.value,
-        "location": finding.location,
+        "location": location,
         "description": finding.description,
         "evidence": finding.evidence,
     }
@@ -109,7 +116,7 @@ def create_baseline(results: dict[str, ScanResult], root: Path) -> dict:
     counts: dict[str, Counter[str]] = {}
     for result in results.values():
         path = _source_path(result.file, root)
-        findings = Counter(_fingerprint(finding) for finding in result.structural_findings)
+        findings = Counter(_fingerprint(finding, result.file, path) for finding in result.structural_findings)
         counts[path] = counts.get(path, Counter()) | findings
     return _validate({
         "schema": SCHEMA,
@@ -181,7 +188,7 @@ def apply_baseline(results: dict[str, ScanResult], payload: dict, root: Path) ->
         result = results[key]
         unmatched = []
         for finding in result.structural_findings:
-            identity = (paths[key], _fingerprint(finding))
+            identity = (paths[key], _fingerprint(finding, result.file, paths[key]))
             if remaining[identity] > 0:
                 remaining[identity] -= 1
                 suppressed[key] += 1

--- a/src/lintlang/baseline.py
+++ b/src/lintlang/baseline.py
@@ -1,0 +1,191 @@
+"""Deterministic, count-limited baselines for existing structural findings.
+
+Only relative source paths and hashes are persisted. Matching includes the exact
+finding location and message, so detector or source changes conservatively remain
+visible. HERM scores and input errors are never changed by a baseline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from collections import Counter
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+from . import __version__
+from .patterns import Finding
+from .scanner import ScanResult
+
+SCHEMA = "lintlang/baseline-v1"
+
+
+class BaselineError(ValueError):
+    """A baseline or its source paths cannot be used safely."""
+
+
+def _valid_path(value: object) -> bool:
+    if not isinstance(value, str) or not value or "\\" in value:
+        return False
+    if any(ord(character) < 32 for character in value):
+        return False
+    path = PurePosixPath(value)
+    return (
+        not path.is_absolute()
+        and not PureWindowsPath(value).drive
+        and path.as_posix() == value
+        and all(part not in {"", ".", ".."} for part in value.split("/"))
+    )
+
+
+def _validate(payload: object) -> dict:
+    if not isinstance(payload, dict) or set(payload) != {"schema", "generator", "entries"}:
+        raise BaselineError("Baseline must contain exactly schema, generator, and entries")
+    if payload["schema"] != SCHEMA:
+        raise BaselineError(f"Unsupported baseline schema; expected {SCHEMA}")
+    if not isinstance(payload["generator"], str) or not payload["generator"].strip():
+        raise BaselineError("Baseline generator must be a nonempty version string")
+    if not isinstance(payload["entries"], list):
+        raise BaselineError("Baseline entries must be a list")
+
+    entries = []
+    seen = set()
+    for index, entry in enumerate(payload["entries"]):
+        if not isinstance(entry, dict) or set(entry) != {"path", "fingerprint", "count"}:
+            raise BaselineError(f"Baseline entry {index} must contain exactly path, fingerprint, and count")
+        if not _valid_path(entry["path"]):
+            raise BaselineError(f"Baseline entry {index} requires a canonical relative POSIX file path")
+        fingerprint = entry["fingerprint"]
+        if not isinstance(fingerprint, str) or re.fullmatch(r"[0-9a-f]{64}", fingerprint) is None:
+            raise BaselineError(f"Baseline entry {index} requires a lowercase SHA-256 fingerprint")
+        if type(entry["count"]) is not int or entry["count"] <= 0:
+            raise BaselineError(f"Baseline entry {index} count must be a positive integer")
+        identity = (entry["path"], fingerprint)
+        if identity in seen:
+            raise BaselineError(f"Baseline entry {index} duplicates a path and fingerprint")
+        seen.add(identity)
+        entries.append(dict(entry))
+    return {
+        "schema": SCHEMA,
+        "generator": payload["generator"],
+        "entries": sorted(entries, key=lambda entry: (entry["path"], entry["fingerprint"])),
+    }
+
+
+def _source_path(source: str, root: Path) -> str:
+    try:
+        relative = Path(source).resolve().relative_to(root.resolve()).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise BaselineError(f"Baseline source must be inside the root: {source}") from error
+    if not _valid_path(relative):
+        raise BaselineError(f"Baseline source requires a relative file path: {source}")
+    return relative
+
+
+def _fingerprint(finding: Finding) -> str:
+    identity = {
+        "code": finding.code,
+        "severity": finding.severity.value,
+        "location": finding.location,
+        "description": finding.description,
+        "evidence": finding.evidence,
+    }
+    encoded = json.dumps(identity, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def create_baseline(results: dict[str, ScanResult], root: Path) -> dict:
+    """Record current findings, rejecting empty scans and any input failure.
+
+    Aliases of one canonical file do not multiply the recorded allowance. Each
+    fingerprint keeps the maximum count from any single result for that file.
+    """
+    if not results:
+        raise BaselineError("Cannot create a baseline from an empty scan")
+    if any(result.input_error is not None for result in results.values()):
+        raise BaselineError("Cannot create a baseline while any input has an error")
+    counts: dict[str, Counter[str]] = {}
+    for result in results.values():
+        path = _source_path(result.file, root)
+        findings = Counter(_fingerprint(finding) for finding in result.structural_findings)
+        counts[path] = counts.get(path, Counter()) | findings
+    return _validate({
+        "schema": SCHEMA,
+        "generator": __version__,
+        "entries": [
+            {"path": path, "fingerprint": fingerprint, "count": count}
+            for path, findings in counts.items()
+            for fingerprint, count in findings.items()
+        ],
+    })
+
+
+def write_baseline(path: Path, payload: dict) -> None:
+    """Atomically publish a complete baseline without replacing any existing path."""
+    validated = _validate(payload)
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", dir=path.parent, delete=False) as stream:
+            temporary = Path(stream.name)
+            json.dump(validated, stream, indent=2, sort_keys=True, ensure_ascii=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        # A hard link publishes the completed file and atomically fails if the
+        # destination exists, including a dangling symlink. replace() would clobber.
+        os.link(temporary, path)
+    except (OSError, UnicodeError) as error:
+        raise BaselineError(f"Cannot write baseline: {error}") from error
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def _unique_keys(pairs: list[tuple[str, object]]) -> dict:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise BaselineError("Baseline JSON contains a duplicate object key")
+        result[key] = value
+    return result
+
+
+def load_baseline(path: Path) -> dict:
+    """Read a strictly validated baseline; unknown fields and versions are errors."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=_unique_keys)
+    except (OSError, ValueError, RecursionError) as error:
+        raise BaselineError(f"Cannot read baseline: {error}") from error
+    return _validate(payload)
+
+
+def apply_baseline(results: dict[str, ScanResult], payload: dict, root: Path) -> dict[str, int]:
+    """Remove counted exact matches in place and return suppressed counts per key.
+
+    All paths are checked before results are changed. An input error is retained
+    as-is, with zero suppressions, regardless of any recorded allowance.
+    """
+    validated = _validate(payload)
+    remaining = Counter({
+        (entry["path"], entry["fingerprint"]): entry["count"] for entry in validated["entries"]
+    })
+    paths = {
+        key: _source_path(result.file, root)
+        for key, result in results.items()
+        if result.input_error is None
+    }
+    suppressed = {key: 0 for key in results}
+    for key in sorted(paths):
+        result = results[key]
+        unmatched = []
+        for finding in result.structural_findings:
+            identity = (paths[key], _fingerprint(finding))
+            if remaining[identity] > 0:
+                remaining[identity] -= 1
+                suppressed[key] += 1
+            else:
+                unmatched.append(finding)
+        result.structural_findings = unmatched
+    return suppressed

--- a/src/lintlang/cli.py
+++ b/src/lintlang/cli.py
@@ -80,6 +80,17 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Glob patterns to exclude (e.g., 'CHANGELOG.md' 'docs/**'). Non-prompt files (README, LICENSE, etc.) are skipped automatically.",
     )
+    baseline_group = scan_parser.add_mutually_exclusive_group()
+    baseline_group.add_argument(
+        "--baseline",
+        type=Path,
+        help="Acknowledge exact existing findings from a reviewed baseline; report new findings",
+    )
+    baseline_group.add_argument(
+        "--write-baseline",
+        type=Path,
+        help="Record current findings to a new baseline file without overwriting an existing file",
+    )
     # ── patterns command ───────────────────────────────────────────
     subparsers.add_parser("patterns", help="List all diagnostic patterns")
     configure_init_parser(subparsers)
@@ -125,6 +136,21 @@ def _cmd_scan(args: argparse.Namespace) -> int:
 
     t_start = time.monotonic()
 
+    baseline_data = None
+    baseline_root = None
+    baseline_counts: dict[str, int] = {}
+    baseline_path = args.baseline or args.write_baseline
+    if baseline_path:
+        from .baseline import BaselineError, load_baseline
+        from .sarif import find_repository_root
+
+        baseline_root = find_repository_root(Path.cwd())
+        if args.baseline:
+            try:
+                baseline_data = load_baseline(args.baseline)
+            except (BaselineError, OSError) as error:
+                return _baseline_failure(args, str(error))
+
     severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
     min_sev = severity_order.get(args.min_severity, 4)
 
@@ -158,8 +184,42 @@ def _cmd_scan(args: argparse.Namespace) -> int:
         except Exception as e:
             results[str(path)] = input_error_result(path, f"Failed to parse: {e}")
 
+    if baseline_path:
+        # Directory scans may discover the baseline JSON itself. It is an
+        # acknowledgement file, never another instruction input. Resolve aliases
+        # once so repeated CLI paths cannot enlarge a baseline's allowance.
+        unique_results: dict[str, ScanResult] = {}
+        seen: set[Path] = set()
+        try:
+            resolved_baseline = baseline_path.resolve()
+            for key, result in results.items():
+                # Keep input failures verbatim; even an unresolvable source
+                # must remain a fatal input rather than disappear in filtering.
+                if result.input_error is not None:
+                    unique_results[key] = result
+                    continue
+                source = Path(result.file).resolve()
+                if source == resolved_baseline or source in seen:
+                    continue
+                seen.add(source)
+                unique_results[key] = result
+        except (OSError, RuntimeError) as error:
+            return _baseline_failure(args, str(error))
+        results = unique_results
+
     input_errors = [result for result in results.values() if result.input_error is not None]
     sarif_output_errors: list[str] = []
+    pending_baseline = None
+    if baseline_path:
+        from .baseline import BaselineError, apply_baseline, create_baseline
+
+        try:
+            if args.baseline:
+                baseline_counts = apply_baseline(results, baseline_data, baseline_root)
+            elif results and not input_errors:
+                pending_baseline = create_baseline(results, baseline_root)
+        except (BaselineError, OSError) as error:
+            return _baseline_failure(args, str(error))
 
     if args.format != "sarif":
         for result in input_errors:
@@ -167,17 +227,23 @@ def _cmd_scan(args: argparse.Namespace) -> int:
 
     # Output
     if args.format == "terminal":
-        for result in results.values():
-            print(format_terminal(result, show_suggestions=not args.no_suggestions))
+        for key, result in results.items():
+            print(format_terminal(
+                result, show_suggestions=not args.no_suggestions,
+                baseline_count=baseline_counts.get(key, 0) if args.baseline else None,
+            ))
     elif args.format == "markdown":
-        for result in results.values():
+        for key, result in results.items():
             if result.input_error:
                 print(f"# Lintlang Input Error\n\n- **File:** `{result.file}`\n- **Error:** {result.input_error}\n")
             else:
-                print(format_markdown(result, show_suggestions=not args.no_suggestions))
+                print(format_markdown(
+                    result, show_suggestions=not args.no_suggestions,
+                    baseline_count=baseline_counts.get(key, 0) if args.baseline else None,
+                ))
     elif args.format == "json":
         output = []
-        for result in results.values():
+        for key, result in results.items():
             verdict = compute_verdict(result)
             output.append(
                 {
@@ -213,6 +279,8 @@ def _cmd_scan(args: argparse.Namespace) -> int:
                     },
                 }
             )
+            if args.baseline:
+                output[-1]["baseline"] = {"suppressed": baseline_counts.get(key, 0)}
         print(json_mod.dumps(output, indent=2))
     elif args.format == "sarif":
         from .sarif import (
@@ -233,15 +301,20 @@ def _cmd_scan(args: argparse.Namespace) -> int:
         for error in sarif_output_errors:
             print(f"Error: SARIF output error: {error}", file=sys.stderr)
         try:
-            print(
-                format_sarif(
-                    sarif_results,
-                    repository_root=repository_root,
-                    source_base=invocation_root,
-                    show_suggestions=not args.no_suggestions,
-                ),
-                end="",
+            document = format_sarif(
+                sarif_results,
+                repository_root=repository_root,
+                source_base=invocation_root,
+                show_suggestions=not args.no_suggestions,
             )
+            if args.baseline:
+                parsed = json_mod.loads(document)
+                parsed["runs"][0].setdefault("properties", {})["lintlangBaseline"] = {
+                    "suppressed": sum(baseline_counts.values()),
+                    "verdictScope": "remaining findings",
+                }
+                document = json_mod.dumps(parsed, indent=2) + "\n"
+            print(document, end="")
         except SarifLocationError as error:
             print(f"Error: SARIF output error: {error}", file=sys.stderr)
             print(format_sarif_error(str(error)), end="")
@@ -260,6 +333,17 @@ def _cmd_scan(args: argparse.Namespace) -> int:
     # --fail-on. Never let another valid input mask a requested input error.
     if input_errors or sarif_output_errors:
         return 1
+
+    if pending_baseline is not None:
+        from .baseline import BaselineError, write_baseline
+
+        try:
+            write_baseline(args.write_baseline, pending_baseline)
+        except (BaselineError, OSError) as error:
+            print(f"Error: Baseline was not written: {error}", file=sys.stderr)
+            return 1
+        count = sum(entry["count"] for entry in pending_baseline["entries"])
+        print(f"Baseline written to {args.write_baseline}: {count} finding(s). Review before committing.", file=sys.stderr)
 
     # Verdict-based exit
     if args.fail_on:
@@ -280,6 +364,24 @@ def _cmd_scan(args: argparse.Namespace) -> int:
             return 1
 
     return 0
+
+
+def _baseline_failure(args: argparse.Namespace, message: str) -> int:
+    """Keep an operational baseline error nonzero and machine-readable."""
+    import json
+
+    print(f"Error: Baseline: {message}", file=sys.stderr)
+    if args.format == "sarif":
+        from .sarif import format_sarif_error
+
+        print(format_sarif_error(f"Baseline error: {message}"), end="")
+    elif args.format == "json":
+        print(json.dumps([{
+            "file": str(args.baseline or args.write_baseline),
+            "verdict": "ERROR", "input_error": f"Baseline error: {message}",
+            "structural_findings": [], "herm": None,
+        }], indent=2))
+    return 1
 
 
 if __name__ == "__main__":

--- a/src/lintlang/report.py
+++ b/src/lintlang/report.py
@@ -108,6 +108,7 @@ def _severity_summary(findings: list[Finding]) -> str:
 def format_terminal(
     result: ScanResult,
     show_suggestions: bool = True,
+    baseline_count: int | None = None,
 ) -> str:
     """Format a ScanResult for terminal output with ANSI colors."""
     lines: list[str] = []
@@ -125,6 +126,8 @@ def format_terminal(
 
     # Verdict
     lines.append(f"  {icon} {BOLD}{vcolor}{verdict}{RESET} — {_severity_summary(findings)}")
+    if baseline_count is not None:
+        lines.append(f"  Baseline: {baseline_count} recorded finding(s) acknowledged; verdict covers remaining findings.")
     lines.append("")
 
     if result.input_error is not None:
@@ -178,6 +181,7 @@ def format_terminal(
 def format_markdown(
     result: ScanResult,
     show_suggestions: bool = True,
+    baseline_count: int | None = None,
 ) -> str:
     """Format a ScanResult as a Markdown document."""
     lines: list[str] = []
@@ -201,6 +205,8 @@ def format_markdown(
 
     # Verdict
     lines.append(f"**Verdict:** {verdict_md} — {_severity_summary(findings)}")
+    if baseline_count is not None:
+        lines.append(f"**Baseline:** {baseline_count} recorded finding(s) acknowledged; verdict covers remaining findings.")
     lines.append("")
 
     # Structural findings

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -24,6 +25,44 @@ def _real_lintlang_path(tmp_path: Path) -> Path:
     return fake_bin
 
 
+def _action_env(tmp_path: Path, source: Path, baseline: Path | None = None, **extra: str) -> dict[str, str]:
+    lintlang_bin = _real_lintlang_path(tmp_path)
+    return {
+        **os.environ,
+        "PATH": f"{lintlang_bin}{os.pathsep}{os.environ['PATH']}",
+        "PYTHONPATH": str(REPO_ROOT / "src"),
+        "LINTLANG_PATH": str(source),
+        "LINTLANG_FAIL_ON": "fail",
+        "LINTLANG_BASELINE": str(baseline) if baseline is not None else "",
+        **extra,
+    }
+
+
+def _run_action(output_format: str, tmp_path: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    scan = ACTION["runs"]["steps"][3 if output_format == "sarif" else 2]
+    return subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", scan["run"]],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _create_baseline(source: Path, baseline: Path, tmp_path: Path) -> bytes:
+    completed = subprocess.run(
+        [sys.executable, "-m", "lintlang", "scan", str(source), "--write-baseline", str(baseline)],
+        cwd=tmp_path,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "src")},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    return baseline.read_bytes()
+
+
 def test_marketplace_metadata_and_inputs_are_minimal():
     assert ACTION["name"] == "LintLang Agent Config Linter"
     assert ACTION["description"]
@@ -32,9 +71,11 @@ def test_marketplace_metadata_and_inputs_are_minimal():
     assert ACTION.get("outputs") is None
 
     inputs = ACTION["inputs"]
-    assert set(inputs) == {"path", "fail-on", "python-version", "sarif-file"}
+    assert set(inputs) == {"path", "fail-on", "baseline", "python-version", "sarif-file"}
     assert inputs["path"]["required"] is True
     assert inputs["fail-on"]["default"] == "fail"
+    assert inputs["baseline"]["required"] is False
+    assert inputs["baseline"]["default"] == ""
     assert inputs["python-version"]["default"] == "3.12"
     assert inputs["sarif-file"]["required"] is False
     assert inputs["sarif-file"]["default"] == ""
@@ -55,14 +96,20 @@ def test_selected_action_ref_is_installed_and_inputs_are_not_shell_interpolated(
     assert scan["env"] == {
         "LINTLANG_PATH": "${{ inputs.path }}",
         "LINTLANG_FAIL_ON": "${{ inputs.fail-on }}",
+        "LINTLANG_BASELINE": "${{ inputs.baseline }}",
     }
-    assert scan["run"] == 'lintlang scan "$LINTLANG_PATH" --fail-on "$LINTLANG_FAIL_ON"'
+    assert 'LINTLANG_ARGS=(scan "$LINTLANG_PATH" --fail-on "$LINTLANG_FAIL_ON")' in scan["run"]
     assert sarif_scan["if"] == "inputs.sarif-file != ''"
     assert sarif_scan["env"] == {
         "LINTLANG_PATH": "${{ inputs.path }}",
         "LINTLANG_FAIL_ON": "${{ inputs.fail-on }}",
+        "LINTLANG_BASELINE": "${{ inputs.baseline }}",
         "LINTLANG_SARIF_FILE": "${{ inputs.sarif-file }}",
     }
+    for step in (scan, sarif_scan):
+        assert 'LINTLANG_ARGS+=(--baseline "$LINTLANG_BASELINE")' in step["run"]
+        assert 'lintlang "${LINTLANG_ARGS[@]}"' in step["run"]
+        assert "--write-baseline" not in step["run"]
     assert "${{" not in install["run"]
     assert "${{" not in scan["run"]
     assert "${{" not in sarif_scan["run"]
@@ -208,3 +255,143 @@ def test_sarif_step_does_not_add_its_output_to_a_directory_scan(tmp_path):
     assert completed.returncode == 0, completed.stderr
     document = json.loads(report.read_text(encoding="utf-8"))
     assert document["runs"][0]["invocations"][0]["executionSuccessful"] is True
+
+
+@pytest.mark.parametrize("output_format", ["terminal", "sarif"])
+@pytest.mark.parametrize("fail_on", ["fail", "review"])
+def test_action_baseline_passes_known_findings_and_fails_new_findings(tmp_path, output_format, fail_on):
+    scan_root = tmp_path / "configs"
+    scan_root.mkdir()
+    source = scan_root / "agent.yaml"
+    original = (REPO_ROOT / "samples" / "bad_tool_descriptions.yaml").read_bytes()
+    source.write_bytes(original)
+    baseline = tmp_path / "baseline.json"
+    baseline_bytes = _create_baseline(scan_root, baseline, tmp_path)
+    report = tmp_path / "report.sarif"
+    env = _action_env(
+        tmp_path,
+        scan_root,
+        baseline,
+        LINTLANG_FAIL_ON=fail_on,
+        LINTLANG_SARIF_FILE=str(report),
+    )
+
+    known = _run_action(output_format, tmp_path, env)
+
+    assert known.returncode == 0, known.stdout + known.stderr
+    if output_format == "sarif":
+        assert json.loads(report.read_text(encoding="utf-8"))["runs"][0]["results"] == []
+
+    new_source = scan_root / "new-agent.yaml"
+    new_source.write_bytes(original)
+    new = _run_action(output_format, tmp_path, env)
+
+    assert new.returncode == 1, new.stdout + new.stderr
+    if output_format == "sarif":
+        assert json.loads(report.read_text(encoding="utf-8"))["runs"][0]["results"]
+    assert baseline.read_bytes() == baseline_bytes
+    assert source.read_bytes() == original
+    assert new_source.read_bytes() == original
+
+
+@pytest.mark.parametrize("output_format", ["terminal", "sarif"])
+@pytest.mark.parametrize("baseline_state", ["missing", "invalid"])
+def test_action_rejects_missing_or_invalid_baseline_without_creating_or_changing_it(
+    tmp_path, output_format, baseline_state
+):
+    source = tmp_path / "agent.yaml"
+    original = b"system_prompt: Be concise.\n"
+    source.write_bytes(original)
+    baseline = tmp_path / "baseline.json"
+    invalid_bytes = b'{"not": "a lintlang baseline"}\n'
+    if baseline_state == "invalid":
+        baseline.write_bytes(invalid_bytes)
+    env = _action_env(tmp_path, source, baseline, LINTLANG_SARIF_FILE=str(tmp_path / "report.sarif"))
+
+    completed = _run_action(output_format, tmp_path, env)
+
+    assert completed.returncode != 0
+    assert source.read_bytes() == original
+    if baseline_state == "missing":
+        assert not baseline.exists()
+    else:
+        assert baseline.read_bytes() == invalid_bytes
+
+
+@pytest.mark.parametrize("output_format", ["terminal", "sarif"])
+def test_action_baseline_does_not_hide_input_errors(tmp_path, output_format):
+    source = tmp_path / "agent.yaml"
+    source.write_bytes((REPO_ROOT / "samples" / "bad_tool_descriptions.yaml").read_bytes())
+    baseline = tmp_path / "baseline.json"
+    baseline_bytes = _create_baseline(source, baseline, tmp_path)
+    invalid_bytes = b"tools: [\n"
+    source.write_bytes(invalid_bytes)
+    env = _action_env(tmp_path, source, baseline, LINTLANG_SARIF_FILE=str(tmp_path / "report.sarif"))
+
+    completed = _run_action(output_format, tmp_path, env)
+
+    assert completed.returncode != 0
+    assert baseline.read_bytes() == baseline_bytes
+    assert source.read_bytes() == invalid_bytes
+
+
+@pytest.mark.parametrize("output_format", ["terminal", "sarif"])
+def test_action_baseline_path_with_shell_metacharacters_is_inert(tmp_path, output_format):
+    source = tmp_path / "agent.yaml"
+    original = (REPO_ROOT / "samples" / "bad_tool_descriptions.yaml").read_bytes()
+    source.write_bytes(original)
+    baseline = tmp_path / "known findings; touch BASELINE_EXECUTED; $(touch BASELINE_SUBSTITUTED).json"
+    baseline_bytes = _create_baseline(source, baseline, tmp_path)
+    env = _action_env(tmp_path, source, baseline, LINTLANG_SARIF_FILE=str(tmp_path / "report.sarif"))
+
+    completed = _run_action(output_format, tmp_path, env)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert not (tmp_path / "BASELINE_EXECUTED").exists()
+    assert not (tmp_path / "BASELINE_SUBSTITUTED").exists()
+    assert baseline.read_bytes() == baseline_bytes
+    assert source.read_bytes() == original
+
+
+@pytest.mark.parametrize("alias", ["same-path", "relative-path", "report-symlink", "baseline-symlink"])
+def test_sarif_step_rejects_baseline_output_collision_before_scanning(tmp_path, alias):
+    source = tmp_path / "agent.yaml"
+    original = (REPO_ROOT / "samples" / "bad_tool_descriptions.yaml").read_bytes()
+    source.write_bytes(original)
+    baseline = tmp_path / "baseline.json"
+    baseline_bytes = _create_baseline(source, baseline, tmp_path)
+    report = baseline
+    if alias == "relative-path":
+        (tmp_path / "nested").mkdir()
+        report = Path("nested/../baseline.json")
+    elif alias == "report-symlink":
+        report = tmp_path / "report.sarif"
+        report.symlink_to(baseline)
+    elif alias == "baseline-symlink":
+        baseline = tmp_path / "baseline-link.json"
+        baseline.symlink_to(report)
+    env = _action_env(tmp_path, source, baseline, LINTLANG_SARIF_FILE=str(report))
+    # Trace the Action's shell: collision rejection must happen before the CLI
+    # invocation and before any report staging or replacement.
+    scan = ACTION["runs"]["steps"][3]
+    completed = subprocess.run(
+        ["bash", "-x", "-e", "-o", "pipefail", "-c", scan["run"]],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert "inputs baseline and sarif-file must differ" in completed.stderr
+    assert "+ lintlang " not in completed.stderr
+    assert "+ mktemp " not in completed.stderr
+    assert "+ mv " not in completed.stderr
+    assert baseline.read_bytes() == baseline_bytes
+    assert (tmp_path / "baseline.json").read_bytes() == baseline_bytes
+    assert source.read_bytes() == original
+    if alias == "report-symlink":
+        assert report.is_symlink()
+    elif alias == "baseline-symlink":
+        assert baseline.is_symlink()

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,326 @@
+"""Behavior and adversarial cases for structural-finding adoption baselines."""
+
+import copy
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from lintlang import __version__
+from lintlang.baseline import SCHEMA, BaselineError, apply_baseline, create_baseline, load_baseline, write_baseline
+from lintlang.herm import score_text
+from lintlang.patterns import Finding, Severity, SourceRegion
+from lintlang.scanner import ScanResult
+
+
+def finding(**changes):
+    defaults = {
+        "pattern_id": "H1",
+        "sub_id": "H1.6",
+        "pattern_name": "Tool Description Ambiguity",
+        "severity": Severity.HIGH,
+        "location": "tools[0].description",
+        "description": "Private description: alpha-secret",
+        "suggestion": "Private suggestion: bravo-secret",
+        "evidence": "Private prompt excerpt: charlie-secret",
+    }
+    defaults.update(changes)
+    return Finding(**defaults)
+
+
+def result(path, findings=(), error=None):
+    herm = score_text("", source_path=str(path))
+    return ScanResult(str(path), herm.score, herm, list(findings), error)
+
+
+def payload():
+    return {
+        "schema": SCHEMA,
+        "generator": __version__,
+        "entries": [{"path": "agent.yaml", "fingerprint": "a" * 64, "count": 1}],
+    }
+
+
+def test_generation_is_deterministic_and_omits_private_content(tmp_path):
+    first = result(tmp_path / "z.prompt", [finding(), finding(), finding(evidence="different")])
+    second = result(tmp_path / "nested" / "a.yaml", [finding()])
+    forward = create_baseline({"z": first, "a": second}, tmp_path)
+    backward = create_baseline({"a": second, "z": result(first.file, reversed(first.structural_findings))}, tmp_path)
+    assert forward == backward
+    assert forward["entries"] == sorted(forward["entries"], key=lambda entry: (entry["path"], entry["fingerprint"]))
+    assert sorted(entry["count"] for entry in forward["entries"]) == [1, 1, 2]
+    write_baseline(tmp_path / "one.json", forward)
+    write_baseline(tmp_path / "two.json", backward)
+    contents = (tmp_path / "one.json").read_text()
+    assert contents == (tmp_path / "two.json").read_text()
+    assert contents.endswith("\n")
+    for secret in ["alpha-secret", "bravo-secret", "charlie-secret", str(tmp_path), "tools[0].description"]:
+        assert secret not in contents
+    assert load_baseline(tmp_path / "one.json") == forward
+
+
+def test_fingerprint_has_documented_canonical_identity(tmp_path):
+    item = finding()
+    expected = hashlib.sha256(json.dumps({
+        "code": item.code,
+        "severity": item.severity.value,
+        "location": item.location,
+        "description": item.description,
+        "evidence": item.evidence,
+    }, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()).hexdigest()
+    baseline = create_baseline({"file": result(tmp_path / "agent.yaml", [item])}, tmp_path)
+    assert baseline["entries"][0]["fingerprint"] == expected
+
+
+@pytest.mark.parametrize("changes", [
+    {"severity": Severity.CRITICAL},
+    {"sub_id": "H1.7"},
+    {"sub_id": "", "pattern_id": "H2"},
+    {"location": "tools[1].description"},
+    {"description": "Reworded diagnosis"},
+    {"evidence": "Changed evidence"},
+])
+def test_changed_identity_remains_new(tmp_path, changes):
+    path = tmp_path / "agent.yaml"
+    baseline = create_baseline({str(path): result(path, [finding()])}, tmp_path)
+    changed = finding(**changes)
+    current = {str(path): result(path, [changed])}
+    assert apply_baseline(current, baseline, tmp_path) == {str(path): 0}
+    assert current[str(path)].structural_findings == [changed]
+
+
+def test_suggestion_region_and_display_name_do_not_change_identity(tmp_path):
+    path = tmp_path / "agent.yaml"
+    baseline = create_baseline({"key": result(path, [finding()])}, tmp_path)
+    current = {"key": result(path, [finding(
+        suggestion="Updated guidance", source_region=SourceRegion(12, 15), pattern_name="New display name",
+    )])}
+    herm = current["key"].herm
+    score = current["key"].score
+    assert apply_baseline(current, baseline, tmp_path) == {"key": 1}
+    assert current["key"].structural_findings == []
+    assert current["key"].herm is herm
+    assert current["key"].score == score
+
+
+def test_count_budget_new_findings_and_different_files(tmp_path):
+    path = tmp_path / "agent.yaml"
+    baseline = create_baseline({"original": result(path, [finding(), finding()])}, tmp_path)
+    extra = finding(evidence="new finding")
+    current = {
+        "original": result(path, [finding(), extra, finding(), finding()]),
+        "different": result(tmp_path / "other.yaml", [finding()]),
+    }
+    assert apply_baseline(current, baseline, tmp_path) == {"original": 2, "different": 0}
+    assert current["original"].structural_findings == [extra, finding()]
+    assert current["different"].structural_findings == [finding()]
+
+
+def test_aliases_share_allowance_on_generation_and_application(tmp_path):
+    source = tmp_path / "agent.yaml"
+    source.touch()
+    alias = tmp_path / "alias.yaml"
+    alias.symlink_to(source)
+    baseline = create_baseline({
+        "first": result(source, [finding()]),
+        "second": result(alias, [finding(), finding()]),
+    }, tmp_path)
+    assert len(baseline["entries"]) == 1
+    assert baseline["entries"][0]["path"] == "agent.yaml"
+    assert baseline["entries"][0]["count"] == 2
+    current = {"second": result(alias, [finding(), finding()]), "first": result(source, [finding()])}
+    assert apply_baseline(current, baseline, tmp_path) == {"second": 1, "first": 1}
+    assert current["first"].structural_findings == []
+    assert current["second"].structural_findings == [finding()]
+
+
+def test_relative_source_paths_follow_scan_path_semantics(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    baseline = create_baseline({"key": result(Path("config") / "agent.yaml", [finding()])}, Path("config"))
+    assert baseline["entries"][0]["path"] == "agent.yaml"
+
+
+def test_no_findings_is_a_valid_baseline_but_empty_scan_is_not(tmp_path):
+    with pytest.raises(BaselineError, match="empty scan"):
+        create_baseline({}, tmp_path)
+    baseline = create_baseline({"key": result(tmp_path / "agent.yaml")}, tmp_path)
+    assert baseline["entries"] == []
+    current = {"key": result(tmp_path / "agent.yaml", [finding()])}
+    assert apply_baseline(current, baseline, tmp_path) == {"key": 0}
+    assert current["key"].structural_findings == [finding()]
+
+
+def test_input_errors_reject_generation_and_are_never_suppressed(tmp_path):
+    path = tmp_path / "agent.yaml"
+    clean = result(path, [finding()])
+    baseline = create_baseline({"key": clean}, tmp_path)
+    failed = replace(clean, input_error="Cannot parse source")
+    with pytest.raises(BaselineError, match="input has an error"):
+        create_baseline({"clean": clean, "failed": failed}, tmp_path)
+    current = {"failed": failed, "clean": clean}
+    assert apply_baseline(current, baseline, tmp_path) == {"failed": 0, "clean": 1}
+    assert failed.input_error == "Cannot parse source"
+    assert failed.structural_findings == [finding()]
+
+
+@pytest.mark.parametrize("through_symlink", [False, True])
+def test_outside_sources_are_rejected_before_any_mutation(tmp_path, through_symlink):
+    root = tmp_path / "repo"
+    root.mkdir()
+    outside = tmp_path / "outside.yaml"
+    outside.touch()
+    source = outside
+    if through_symlink:
+        source = root / "escape.yaml"
+        source.symlink_to(outside)
+    valid = result(root / "valid.yaml", [finding()])
+    baseline = create_baseline({"valid": valid}, root)
+    results = {"valid": valid, "outside": result(source, [finding()])}
+    with pytest.raises(BaselineError, match="inside the root"):
+        create_baseline(results, root)
+    with pytest.raises(BaselineError, match="inside the root"):
+        apply_baseline(results, baseline, root)
+    assert valid.structural_findings == [finding()]
+
+
+@pytest.mark.parametrize("invalid", [
+    None, [], "baseline", {},
+    {"schema": SCHEMA, "entries": []},
+    {"schema": "lintlang/baseline-v2", "generator": "1", "entries": []},
+    {"schema": SCHEMA, "generator": 1, "entries": []},
+    {"schema": SCHEMA, "generator": " ", "entries": []},
+    {"schema": SCHEMA, "generator": "1", "entries": {}},
+    {"schema": SCHEMA, "generator": "1", "entries": [], "ignore_all": True},
+])
+def test_reject_invalid_top_level(tmp_path, invalid):
+    path = tmp_path / "baseline.json"
+    path.write_text(json.dumps(invalid))
+    with pytest.raises(BaselineError):
+        load_baseline(path)
+
+
+@pytest.mark.parametrize(("field", "value"), [
+    ("path", value) for value in [
+        None, True, 12, "", ".", "..", "../agent.yaml", "/agent.yaml", "a/../b.yaml", "./agent.yaml",
+        "a//b.yaml", "agent.yaml/", "a/./b.yaml", "C:/agent.yaml", "C:agent.yaml", "a\\b.yaml",
+        "//server/agent.yaml", "agent\x00.yaml", "agent\n.yaml",
+    ]
+] + [
+    ("fingerprint", value) for value in [None, 123, True, "", "*", "a" * 63, "a" * 65, "A" * 64, "g" * 64]
+] + [
+    ("count", value) for value in [None, "1", True, False, 0, -1, 1.0, float("inf")]
+])
+def test_reject_invalid_entry_values(tmp_path, field, value):
+    invalid = payload()
+    invalid["entries"][0][field] = value
+    path = tmp_path / "baseline.json"
+    path.write_text(json.dumps(invalid))
+    with pytest.raises(BaselineError):
+        load_baseline(path)
+
+
+@pytest.mark.parametrize("entry", [None, [], "all", {}, {"path": "agent.yaml", "fingerprint": "a" * 64}])
+def test_reject_invalid_entry_shapes(tmp_path, entry):
+    invalid = payload()
+    invalid["entries"] = [entry]
+    path = tmp_path / "baseline.json"
+    path.write_text(json.dumps(invalid))
+    with pytest.raises(BaselineError):
+        load_baseline(path)
+
+
+def test_reject_extra_fields_duplicate_entries_and_json_keys(tmp_path):
+    invalid = payload()
+    invalid["entries"][0]["ignore"] = True
+    with pytest.raises(BaselineError):
+        apply_baseline({}, invalid, tmp_path)
+    invalid = payload()
+    invalid["entries"].append(copy.deepcopy(invalid["entries"][0]))
+    with pytest.raises(BaselineError, match="duplicates"):
+        write_baseline(tmp_path / "invalid.json", invalid)
+    assert not (tmp_path / "invalid.json").exists()
+    path = tmp_path / "duplicate.json"
+    path.write_text('{"schema":"bad","schema":"lintlang/baseline-v1","generator":"1","entries":[]}')
+    with pytest.raises(BaselineError, match="duplicate object key"):
+        load_baseline(path)
+
+
+@pytest.mark.parametrize("contents", ["{", "", "null", "{} {}"])
+def test_load_invalid_json(tmp_path, contents):
+    path = tmp_path / "baseline.json"
+    path.write_text(contents)
+    with pytest.raises(BaselineError):
+        load_baseline(path)
+
+
+def test_load_missing_file_and_invalid_utf8(tmp_path):
+    with pytest.raises(BaselineError):
+        load_baseline(tmp_path / "missing.json")
+    path = tmp_path / "invalid.json"
+    path.write_bytes(b"\xff")
+    with pytest.raises(BaselineError):
+        load_baseline(path)
+
+
+def test_excessively_nested_json_reports_baseline_error(tmp_path):
+    path = tmp_path / "nested.json"
+    path.write_text("[" * 10000 + "0" + "]" * 10000)
+    with pytest.raises(BaselineError):
+        load_baseline(path)
+
+
+@pytest.mark.parametrize("kind", ["file", "directory", "symlink", "dangling-symlink"])
+def test_write_never_clobbers_existing_destination(tmp_path, kind):
+    destination = tmp_path / "baseline.json"
+    target = tmp_path / "target"
+    if kind == "file":
+        destination.write_text("existing baseline")
+    elif kind == "directory":
+        destination.mkdir()
+    else:
+        if kind == "symlink":
+            target.write_text("private data")
+        destination.symlink_to(target)
+    before = sorted(path.name for path in tmp_path.iterdir())
+    with pytest.raises(BaselineError, match="Cannot write baseline"):
+        write_baseline(destination, payload())
+    assert sorted(path.name for path in tmp_path.iterdir()) == before
+    if kind == "file":
+        assert destination.read_text() == "existing baseline"
+    elif kind == "symlink":
+        assert destination.is_symlink()
+        assert target.read_text() == "private data"
+    elif kind == "dangling-symlink":
+        assert destination.is_symlink()
+        assert not target.exists()
+    else:
+        assert destination.is_dir()
+
+
+def test_failed_write_leaves_no_partial_destination_or_temporary_file(tmp_path, monkeypatch):
+    def fail_sync(_descriptor):
+        raise OSError("simulated disk error")
+
+    monkeypatch.setattr("lintlang.baseline.os.fsync", fail_sync)
+    with pytest.raises(BaselineError, match="simulated disk error"):
+        write_baseline(tmp_path / "baseline.json", payload())
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_invalid_payload_apply_is_atomic(tmp_path):
+    current = {"key": result(tmp_path / "agent.yaml", [finding()])}
+    invalid = create_baseline(current, tmp_path)
+    invalid["entries"][0]["count"] = True
+    with pytest.raises(BaselineError):
+        apply_baseline(current, invalid, tmp_path)
+    assert current["key"].structural_findings == [finding()]
+
+
+def test_literal_glob_path_cannot_match_unrelated_files(tmp_path):
+    wildcard = result(tmp_path / "*.yaml", [finding()])
+    baseline = create_baseline({"wildcard": wildcard}, tmp_path)
+    current = {"key": result(tmp_path / "agent.yaml", [finding()])}
+    assert apply_baseline(current, baseline, tmp_path) == {"key": 0}
+    assert current["key"].structural_findings == [finding()]

--- a/tests/test_baseline_cli.py
+++ b/tests/test_baseline_cli.py
@@ -1,0 +1,111 @@
+"""Baseline adoption through the real CLI, including output and error contracts."""
+
+import json
+import shutil
+
+import pytest
+
+from lintlang.cli import main
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+    source = tmp_path / "agent.yaml"
+    source.write_text("system_prompt: Keep trying until it works.\n")
+    return tmp_path
+
+
+def scan(capsys, *args):
+    status = main(["scan", *args, "--format", "json"])
+    output = capsys.readouterr()
+    return status, json.loads(output.out), output.err
+
+
+def baseline(capsys):
+    status, original, _ = scan(capsys, "agent.yaml", "--write-baseline", "baseline.json")
+    assert status == 0
+    assert original[0]["structural_findings"]
+    return original[0]
+
+
+def test_existing_findings_acknowledged_new_file_blocks_and_herm_unchanged(project, capsys):
+    original = baseline(capsys)
+    status, data, _ = scan(capsys, ".", "--baseline", "baseline.json", "--fail-on", "review")
+    assert status == 0
+    assert len(data) == 1  # The stored baseline is not an instruction input.
+    assert data[0]["structural_findings"] == []
+    assert data[0]["baseline"]["suppressed"] == len(original["structural_findings"])
+    assert data[0]["herm"] == original["herm"]
+    assert "baseline" not in original
+
+    shutil.copyfile("agent.yaml", "new-agent.yaml")
+    status, data, _ = scan(capsys, ".", "--baseline", "baseline.json", "--fail-on", "review")
+    assert status == 1
+    new = next(result for result in data if result["file"].endswith("new-agent.yaml"))
+    assert new["structural_findings"]
+    assert new["baseline"]["suppressed"] == 0
+
+
+def test_baseline_portable_to_new_checkout_and_git_subdirectory(project, tmp_path_factory, monkeypatch, capsys):
+    (project / "configs").mkdir()
+    (project / "agent.yaml").rename(project / "configs/agent.yaml")
+    assert scan(capsys, "configs", "--write-baseline", "baseline.json")[0] == 0
+    copied = tmp_path_factory.mktemp("checkout")
+    shutil.copytree(project, copied, dirs_exist_ok=True)
+    monkeypatch.chdir(copied / "configs")
+    status, data, _ = scan(capsys, "agent.yaml", "--baseline", "../baseline.json", "--fail-on", "review")
+    assert status == 0
+    assert data[0]["baseline"]["suppressed"] > 0
+
+
+def test_input_failure_never_creates_or_is_hidden_by_baseline(project, capsys):
+    original = baseline(capsys)
+    status, data, _ = scan(capsys, "agent.yaml", "missing.yaml", "--baseline", "baseline.json")
+    assert status == 1
+    assert data[0]["herm"] == original["herm"]
+    assert data[1]["verdict"] == "ERROR"
+    assert data[1]["baseline"]["suppressed"] == 0
+    assert scan(capsys, "agent.yaml", "missing.yaml", "--write-baseline", "candidate.json")[0] == 1
+    assert not (project / "candidate.json").exists()
+
+
+def test_empty_scan_and_existing_destination_cannot_write(project, capsys):
+    (project / "empty").mkdir()
+    assert scan(capsys, "empty", "--write-baseline", "empty.json")[0] == 1
+    assert not (project / "empty.json").exists()
+    baseline(capsys)
+    before = (project / "baseline.json").read_bytes()
+    assert scan(capsys, "agent.yaml", "--write-baseline", "baseline.json")[0] == 1
+    assert (project / "baseline.json").read_bytes() == before
+
+
+@pytest.mark.parametrize("output_format", ["terminal", "markdown"])
+def test_human_output_states_verdict_scope(project, capsys, output_format):
+    baseline(capsys)
+    assert main(["scan", "agent.yaml", "--baseline", "baseline.json", "--format", output_format]) == 0
+    assert "verdict covers remaining findings" in capsys.readouterr().out
+
+
+def test_sarif_reports_baseline_scope_and_empty_results(project, capsys):
+    baseline(capsys)
+    assert main(["scan", "agent.yaml", "--baseline", "baseline.json", "--format", "sarif"]) == 0
+    run = json.loads(capsys.readouterr().out)["runs"][0]
+    assert run["results"] == []
+    assert run["properties"]["lintlangBaseline"]["suppressed"] > 0
+    assert run["properties"]["lintlangBaseline"]["verdictScope"] == "remaining findings"
+
+
+def test_baseline_does_not_bypass_legacy_quality_gate(project, capsys):
+    original = baseline(capsys)
+    threshold = str(original["herm"]["score"] + 1)
+    assert scan(capsys, "agent.yaml", "--baseline", "baseline.json", "--fail-under", threshold)[0] == 1
+
+
+def test_repeated_cli_aliases_do_not_duplicate_output_or_allowance(project, capsys):
+    original = baseline(capsys)
+    status, data, _ = scan(capsys, "agent.yaml", str(project / "agent.yaml"), "--baseline", "baseline.json")
+    assert status == 0
+    assert len(data) == 1
+    assert data[0]["baseline"]["suppressed"] == len(original["structural_findings"])

--- a/tests/test_baseline_cli.py
+++ b/tests/test_baseline_cli.py
@@ -109,3 +109,32 @@ def test_repeated_cli_aliases_do_not_duplicate_output_or_allowance(project, caps
     assert status == 0
     assert len(data) == 1
     assert data[0]["baseline"]["suppressed"] == len(original["structural_findings"])
+
+
+@pytest.mark.parametrize(("python_source", "expected_codes"), [
+    ("CONFIDENCE_THRESHOLD = 0.75\n", {"P1"}),
+    (f"SYSTEM_PROMPT = {('You are an assistant. ' + 'Keep trying until it works. ' * 25)!r}\n", {"P2", "H2"}),
+], ids=["threshold", "embedded-prompt"])
+def test_python_baseline_survives_checkout_and_invocation_path_changes(
+    project, tmp_path_factory, monkeypatch, capsys, python_source, expected_codes,
+):
+    configs = project / "configs"
+    configs.mkdir()
+    source = configs / "pipeline.py"
+    source.write_text(python_source)
+    status, original, _ = scan(capsys, str(source), "--write-baseline", "python-baseline.json")
+    assert status == 0
+    assert expected_codes <= {finding["code"] for finding in original[0]["structural_findings"]}
+    copied = tmp_path_factory.mktemp("python-checkout")
+    shutil.copytree(project, copied, dirs_exist_ok=True)
+    monkeypatch.chdir(copied / "configs")
+    status, data, _ = scan(capsys, "pipeline.py", "--baseline", "../python-baseline.json", "--fail-on", "review")
+    assert status == 0
+    assert data[0]["structural_findings"] == []
+    assert data[0]["baseline"]["suppressed"] == len(original[0]["structural_findings"])
+
+    # Canonicalizing the path must not erase actual location changes.
+    (copied / "configs/pipeline.py").write_text("\n" + python_source)
+    status, data, _ = scan(capsys, "pipeline.py", "--baseline", "../python-baseline.json", "--fail-on", "review")
+    assert status == 1
+    assert expected_codes <= {finding["code"] for finding in data[0]["structural_findings"]}


### PR DESCRIPTION
An existing repository may have known findings that already exceed its desired CI threshold. Severity filters and path exclusions reduce coverage for future changes as well. This change adds opt-in reviewed baselines so maintainers can acknowledge specific existing findings while the remaining findings still determine the verdict.

`scan --write-baseline FILE` creates a new file with repository-relative paths, exact finding fingerprints, and occurrence counts. `scan --baseline FILE` applies those allowances. The first-party Action accepts the same baseline in terminal and SARIF modes, and reports disclose the acknowledged count. Missing or malformed inputs remain fatal, HERM scores are unchanged, and neither baseline creation nor SARIF output may overwrite an existing baseline.

The adoption guide covers CI setup and pruning stale entries. Matching is deliberately exact: detector/location changes may reopen findings, and an identical reintroduced finding can match an old unpruned entry. The feature is documented as unreleased; v0.5.3 does not support it.

Python finding locations normalize their source-path prefix to the repository-relative path, so a baseline created with an absolute path still works in a different checkout or from a Git subdirectory. Regression cases cover thresholds, embedded prompts, and preserved failures after actual line-location changes.

Try the reviewed development source:

```bash
python -m pip install 'git+https://github.com/hermes-labs-ai/lintlang.git@24bd9f2f98e44e5c0157b36b4addebf1945ec44d'
```

The Action can use `hermes-labs-ai/lintlang@24bd9f2f98e44e5c0157b36b4addebf1945ec44d` with the `baseline` input. This PR does not publish a PyPI release; the source commit identifies the implementation even though package metadata still reports 0.5.3.

Validation: 527 tests and 76 subtests passed; Ruff 0.16.1 passed; all five bundled sample outcomes matched expectations. Focused tests execute the actual CLI and Action Bash scripts with existing/new findings, malformed inputs, Python checkout portability, path aliases, and report collisions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-in baselines for acknowledging reviewed findings while reporting and gating new findings.
  - Added baseline support to terminal, Markdown, JSON, and SARIF reports, including acknowledged-finding counts.
  - Added an optional `baseline` input to the GitHub Action.

- **Bug Fixes**
  - Baseline validation rejects invalid, conflicting, or unsafe inputs and prevents overwriting existing files.

- **Documentation**
  - Added guidance for creating, applying, maintaining, and configuring baselines, including matching behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->