### PR TITLE
chore: adopt organization repository standards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      pip:
+        patterns:
+          - "*"

--- a/.github/workflows/lintlang.yml
+++ b/.github/workflows/lintlang.yml
@@ -1,0 +1,16 @@
+name: LintLang
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  language-contract:
+    uses: hermes-labs-ai/.github/.github/workflows/reusable-lintlang.yml@main
+    with:
+      path: AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,13 @@
 - proving an agent is safe in production
 - retrieving preferences from history, deciding truth, or silently rewriting/sending prompts
 
+## Key paths
+
+- `src/lintlang/` — package source (detectors, CLI, preflight)
+- `tests/` — pytest suite, including packaging-boundary and doc-consistency checks
+- `samples/` — clean and deliberately bad fixtures used by CI and docs
+- `action.yml` — the GitHub Action wrapper around the CLI
+
 ## Minimal commands
 
 ```bash
@@ -35,6 +42,7 @@ lintlang scan samples/bad_tool_descriptions.yaml
 printf '%s' 'Is it true that X?' | lintlang preflight - --format json
 pytest -q
 ruff check src/ tests/
+python -m build
 ```
 
 ## Output shape
@@ -65,3 +73,11 @@ ruff check src/ tests/
 - keep the tool fully offline and deterministic
 - keep repository `scan` and in-flight `preflight` result types and exit semantics separate
 - keep heuristic preflight findings notice-only; only exact contract/conflict rules may hold
+
+## Definition of done
+
+- `pytest -q` and `ruff check src/ tests/` pass
+- new or changed detector behavior has a covering test and a fixture in `samples/` if user-visible
+- `lintlang scan samples/clean_config.yaml` still exits clean
+- README, `AGENTS.md`, and CLI `--help` output stay consistent with the change
+- no new performance, accuracy, or production-readiness claim was added without evidence


### PR DESCRIPTION
Adopts the Hermes Labs organization defaults by reference, adds/updates the concise repository-specific AGENTS.md contract, groups weekly Dependabot updates, and keeps specialized CI/release behavior local. Product code is unchanged.\n\nValidation: actionlint + YAML parse; repository lint/test/build commands; LintLang AGENTS.md scan. The reusable organization workflows were merged first in hermes-labs-ai/.github#18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Dependency updates are now grouped by ecosystem to reduce the number of update pull requests.
  - Added automated language-contract linting for pull requests and pushes to the main branch.

- **Documentation**
  - Documented key project paths, the package build command, and completion criteria for changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->