### PR TITLE
docs: add pinned first-success scan recipe

### DIFF
--- a/.github/workflows/hermes-quality.yml
+++ b/.github/workflows/hermes-quality.yml
@@ -1,0 +1,23 @@
+name: Hermes quality rail
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  full:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+      - name: Install project and declared gate tools
+        run: python3 -m pip install -e '.[dev]'
+      - name: Run declared full gate
+        run: python3 .hermes/hermes_gate_runner.py full

--- a/.hermes/gate.toml
+++ b/.hermes/gate.toml
@@ -1,0 +1,67 @@
+version = 1
+
+[gate]
+fast_budget_seconds = 8.0
+full_required_local = false
+adapter_status = "NATIVE_DEFAULT"
+exclusions = [".git/**", ".hermes/hermes_gate_runner.py", ".pytest_cache/**", ".ruff_cache/**", "**/__pycache__/**", "vendor/**", "node_modules/**", "dist/**", "build/**"]
+
+[adapter]
+enabled = false
+name = "native"
+argv = []
+minimum_version = ""
+
+[lintlang]
+enabled = true
+argv = ["lintlang", "scan", "--format", "json", "--fail-on", "review", "{files}"]
+trigger_globs = ["**/AGENTS.md", "**/CLAUDE.md", "**/prompts/**", "**/*.prompt", ".codex/**", ".claude/**"]
+timeout_seconds = 4.0
+blocking_threshold = "MEDIUM"
+
+[review]
+provider = "coderabbit"
+argv = ["coderabbit", "review", "--agent"]
+timeout_seconds = 180.0
+material_severities = ["critical", "major"]
+material_categories = ["correctness", "security", "data-loss", "concurrency", "api-contract"]
+fallback_argv = []
+
+[[fast]]
+name = "ruff"
+argv = ["ruff", "check", "{files}"]
+timeout_seconds = 6.0
+globs = ["**/*.py"]
+
+[[fast]]
+name = "python-parse"
+argv = ["python3", "-c", "import ast,pathlib,sys; [ast.parse(pathlib.Path(p).read_bytes(), filename=p) for p in sys.argv[1:]]", "{files}"]
+timeout_seconds = 6.0
+globs = ["**/*.py"]
+
+[[fast]]
+name = "diff-check"
+argv = ["python3", ".hermes/hermes_gate_runner.py", "diff-check", "{files}"]
+timeout_seconds = 4.0
+globs = ["**/*"]
+
+[[full]]
+name = "ruff"
+# The generated runner is kept byte-for-byte (see .hermes/gate.toml exclusions
+# and the recorded runner_sha256), so its three SIM105 findings cannot be
+# repaired here. Exclude only that file; everything else is still linted.
+argv = ["ruff", "check", "--exclude", ".hermes/hermes_gate_runner.py", "."]
+timeout_seconds = 60.0
+globs = ["**/*"]
+
+[[full]]
+name = "pytest"
+argv = ["python3", "-c", "import sys; sys.path.insert(0, 'src'); import pytest; raise SystemExit(pytest.main(['-q']))"]
+timeout_seconds = 180.0
+globs = ["**/*"]
+
+[[repair]]
+name = "ruff-fix"
+argv = ["ruff", "check", "--fix", "{files}"]
+timeout_seconds = 8.0
+globs = ["**/*.py"]

--- a/.hermes/hermes_gate_runner.py
+++ b/.hermes/hermes_gate_runner.py
@@ -1,0 +1,254 @@
+"""Self-contained deterministic repository runner; copied byte-for-byte by init."""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+# The copied runner has the same minimum runtime as the installed CLI.
+if sys.version_info < (3, 11):
+    raise SystemExit("Hermes Gate runner requires Python 3.11 or newer; use that interpreter to run this file.")
+
+import tomllib
+
+RUNNER_VERSION = "0.1.2"
+OUTPUT_CAP = 65536
+
+
+def _root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=False
+    )
+    if result.returncode:
+        raise RuntimeError("not a Git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def _changed(root: Path) -> list[str]:
+    values: set[str] = set()
+    for args in (
+        ("diff", "--name-only", "-z"),
+        ("diff", "--cached", "--name-only", "-z"),
+        ("ls-files", "--others", "--exclude-standard", "-z"),
+    ):
+        proc = subprocess.run(["git", "-C", str(root), *args], capture_output=True, check=False)
+        values.update(x.decode("utf-8", "surrogateescape") for x in proc.stdout.split(b"\0") if x)
+    return sorted(values)
+
+
+def _match(path: str, pattern: str) -> bool:
+    return fnmatch.fnmatch(path, pattern) or (
+        pattern.startswith("**/") and fnmatch.fnmatch(path, pattern[3:])
+    )
+
+
+def run(
+    mode: str, *, root: Path | None = None, files: list[str] | None = None
+) -> dict[str, object]:
+    started = time.monotonic()
+    root = (root or _root()).resolve()
+    config_path = root / ".hermes" / "gate.toml"
+    if not config_path.is_file():
+        return _result(mode, "NOT_CONFIGURED", started, [], "run hermes-gate init")
+    try:
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return _result(mode, "ERROR", started, [], f"invalid profile: {exc}")
+    paths = list(files) if files is not None else _changed(root)
+    paths = [path for path in paths if os.path.lexists(root / path)]
+    exclusions = config.get("gate", {}).get("exclusions", [])
+    paths = [path for path in paths if not any(_match(path, pattern) for pattern in exclusions)]
+    if mode == "fast" and not paths:
+        return _result(mode, "NOT_APPLICABLE", started, [], "no changed files")
+    commands = list(config.get(mode, []))
+    if not commands:
+        return _result(mode, "NOT_CONFIGURED", started, [], f"no [[{mode}]] commands")
+    budget = (
+        float(config.get("gate", {}).get("fast_budget_seconds", 8.0)) if mode == "fast" else None
+    )
+    checks: list[dict[str, object]] = []
+    for spec in commands:
+        globs = spec.get("globs", ["**/*"])
+        selected = [path for path in paths if any(_match(path, pattern) for pattern in globs)]
+        if mode == "fast" and not selected:
+            continue
+        argv: list[str] = []
+        for part in spec.get("argv", []):
+            argv.extend(selected if part == "{files}" else [part])
+        if not argv or any(not isinstance(part, str) for part in argv):
+            return _result(mode, "ERROR", started, checks, "argv must be a non-empty string array")
+        elapsed = time.monotonic() - started
+        timeout = float(spec.get("timeout_seconds", 8.0))
+        if budget is not None:
+            timeout = min(timeout, max(0.01, budget - elapsed))
+        check = _execute(argv, root, timeout, str(spec.get("name", argv[0])))
+        checks.append(check)
+        if check["status"] != "PASS":
+            return _result(mode, "FAIL", started, checks, str(check.get("reason", "check failed")))
+        if budget is not None and time.monotonic() - started >= budget:
+            return _result(mode, "FAIL", started, checks, "fast budget exhausted")
+    if not checks:
+        return _result(mode, "NOT_APPLICABLE", started, [], "no commands matched changed files")
+    return _result(mode, "PASS", started, checks, "")
+
+
+def _execute(argv: list[str], root: Path, timeout: float, name: str) -> dict[str, object]:
+    started = time.monotonic()
+    try:
+        proc = subprocess.Popen(
+            argv,
+            cwd=root,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+    except FileNotFoundError:
+        return {"name": name, "argv": argv, "status": "FAIL", "reason": "executable unavailable"}
+
+    stdout_capture: dict[str, object] = {"data": b"", "total": 0}
+    stderr_capture: dict[str, object] = {"data": b"", "total": 0}
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+    threads = [
+        threading.Thread(
+            target=_drain_bounded,
+            args=(proc.stdout, OUTPUT_CAP // 2, stdout_capture),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=_drain_bounded,
+            args=(proc.stderr, OUTPUT_CAP // 2, stderr_capture),
+            daemon=True,
+        ),
+    ]
+    for thread in threads:
+        thread.start()
+
+    deadline = started + timeout
+    while proc.poll() is None or any(thread.is_alive() for thread in threads):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(0.01, remaining))
+    timed_out = proc.poll() is None or any(thread.is_alive() for thread in threads)
+    if timed_out:
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            proc.wait(timeout=0.25)
+        except subprocess.TimeoutExpired:
+            pass
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        if proc.poll() is None:
+            proc.wait()
+        for thread in threads:
+            thread.join(timeout=0.5)
+        return {"name": name, "argv": argv, "status": "FAIL", "reason": "timeout"}
+
+    for thread in threads:
+        thread.join()
+    stdout = bytes(stdout_capture["data"])
+    stderr = bytes(stderr_capture["data"])
+    total_output = int(stdout_capture["total"]) + int(stderr_capture["total"])
+    return {
+        "name": name,
+        "argv": argv,
+        "status": "PASS" if proc.returncode == 0 else "FAIL",
+        "returncode": proc.returncode,
+        "elapsed_ms": round((time.monotonic() - started) * 1000),
+        "stdout": stdout.decode("utf-8", "replace"),
+        "stderr": stderr.decode("utf-8", "replace"),
+        "output_truncated": total_output > len(stdout) + len(stderr),
+    }
+
+
+def _drain_bounded(pipe, cap: int, capture: dict[str, object]) -> None:
+    kept = bytearray()
+    total = 0
+    try:
+        while chunk := pipe.read(65536):
+            total += len(chunk)
+            remaining = cap - len(kept)
+            if remaining > 0:
+                kept.extend(chunk[:remaining])
+    finally:
+        pipe.close()
+        capture["data"] = bytes(kept)
+        capture["total"] = total
+
+
+def _diff_check(root: Path, paths: list[str]) -> int:
+    """Check selected worktree, index and untracked bytes using Git's whitespace rules."""
+    if not paths:
+        return 0
+    git = ["git", "--literal-pathspecs", "-C", str(root)]
+    for flags in ([], ["--cached"]):
+        result = subprocess.run([*git, "diff", *flags, "--check", "--", *paths], check=False)
+        if result.returncode:
+            return result.returncode
+    untracked = subprocess.run(
+        [*git, "ls-files", "--others", "--exclude-standard", "-z", "--", *paths],
+        capture_output=True, check=False,
+    )
+    if untracked.returncode:
+        sys.stderr.buffer.write(untracked.stderr)
+        return untracked.returncode
+    for raw in untracked.stdout.split(b"\0"):
+        if not raw:
+            continue
+        path = root / os.fsdecode(raw)
+        # Git stores a symlink target, not the contents of its destination.
+        if path.is_symlink() or not path.is_file():
+            continue
+        result = subprocess.run(
+            [*git, "diff", "--no-index", "--check", "--", os.devnull, str(path)],
+            check=False,
+        )
+        # --no-index implies --exit-code: 1 means a clean new-file diff;
+        # --check reports whitespace errors with bit 2 set.
+        if result.returncode not in (0, 1):
+            return result.returncode
+    return 0
+
+
+def _result(
+    mode: str, status: str, started: float, checks: list[dict[str, object]], reason: str
+) -> dict[str, object]:
+    return {
+        "schema": "hermes-gate/runner-v1",
+        "runner_version": RUNNER_VERSION,
+        "command": mode,
+        "status": status,
+        "elapsed_ms": round((time.monotonic() - started) * 1000),
+        "checks": checks,
+        "reason": reason,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if args and args[0] == "diff-check":
+        return _diff_check(_root(), args[1:])
+    if not args or args[0] not in {"fast", "full"}:
+        print(json.dumps({"status": "ERROR", "reason": "usage: runner.py fast|full"}))
+        return 2
+    result = run(args[0])
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["status"] in {"PASS", "NOT_APPLICABLE"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -138,6 +138,85 @@ Baseline matching is exact and count-limited. Changed findings and findings in
 another file remain visible. Invalid inputs still fail; HERM scores are
 unchanged. See the guide for CI configuration, maintenance, and matching limits.
 
+## First run without a checkout
+
+No clone, no credential. You write two small files and run three scans.
+
+Only the install reaches the network — `pip` resolves and downloads from your
+package index. Every `lintlang scan` below is offline and deterministic: it
+reads the file you name and nothing else, no credential, no private file, no
+network.
+
+```bash
+python -m pip install lintlang==0.5.3
+
+cat > /tmp/agent.yaml <<'YAML'
+system_prompt: |
+  You are a support agent. Use the tools to help the user.
+tools:
+  - name: process_ticket
+    description: ""
+    parameters:
+      type: object
+      properties:
+        ticket_id:
+          type: string
+YAML
+
+lintlang scan /tmp/agent.yaml --fail-on fail
+```
+
+The pin is the release this block was verified against; drop it to take the
+latest, and re-read the counts below as approximate if you do.
+
+`lintlang 0.5.3` reports `FAIL — 1 CRITICAL, 1 HIGH, 1 MEDIUM` and exits `1`.
+The `CRITICAL` is `H1.1 tool:process_ticket` — "Tool 'process_ticket' has no
+description." Under `--fail-on fail` that exit `1` is a successful detection,
+not a broken install. Do not hide it with `|| true`.
+
+Give the tool a disambiguating description and add the bounds `H2` looks for:
+
+```bash
+cat > /tmp/agent-fixed.yaml <<'YAML'
+system_prompt: |
+  You are a support agent. Use the tools to help the user.
+  Stop and report the failure once the retry limit is reached.
+tools:
+  - name: process_ticket
+    description: "Apply a resolution action to one existing support ticket. Use this only after the ticket has been read; do NOT use it to look tickets up."
+    parameters:
+      type: object
+      properties:
+        ticket_id:
+          type: string
+          description: "Identifier of the existing ticket to act on"
+      required: [ticket_id]
+constraints:
+  max_iterations: 3
+  timeout_seconds: 30
+YAML
+
+lintlang scan /tmp/agent-fixed.yaml --fail-on fail
+```
+
+`H1.1` is gone. On `lintlang 0.5.3` this pair of files scans `PASS — 0
+findings` and exits `0`.
+
+An input that cannot be scanned stays a separate outcome, so CI can tell
+"findings" apart from "the linter never ran":
+
+```bash
+lintlang scan /tmp/does-not-exist.yaml --fail-on fail
+```
+
+That prints the verdict `ERROR` with `Input error: File not found` and exits
+nonzero. `--format json` carries the same distinction as `verdict` plus a
+non-null `input_error`.
+
+`PASS` here means the selected checks found nothing above `LOW` in the content
+lintlang extracted from these two files. It is not evidence that the agent is
+safe or runtime-correct.
+
 ## Try the bundled example
 
 The source repository includes a deliberately broken example:

--- a/README.md
+++ b/README.md
@@ -166,8 +166,15 @@ YAML
 lintlang scan /tmp/agent.yaml --fail-on fail
 ```
 
-The pin is the release this block was verified against; drop it to take the
-latest, and re-read the counts below as approximate if you do.
+The pin is the release this block was verified against. To take the latest
+release instead, run:
+
+```bash
+python -m pip install --upgrade lintlang
+```
+
+and re-read the counts below as approximate — a newer release may report
+different findings.
 
 `lintlang 0.5.3` reports `FAIL — 1 CRITICAL, 1 HIGH, 1 MEDIUM` and exits `1`.
 The `CRITICAL` is `H1.1 tool:process_ticket` — "Tool 'process_ticket' has no
@@ -199,8 +206,9 @@ YAML
 lintlang scan /tmp/agent-fixed.yaml --fail-on fail
 ```
 
-`H1.1` is gone. On `lintlang 0.5.3` this pair of files scans `PASS — 0
-findings` and exits `0`.
+`H1.1` is gone. On `lintlang 0.5.3` the fixed file scans `PASS — 0 findings`
+and exits `0`. Only `/tmp/agent-fixed.yaml` passes: the original
+`/tmp/agent.yaml` still scans `FAIL` and still exits `1`.
 
 An input that cannot be scanned stays a separate outcome, so CI can tell
 "findings" apart from "the linter never ran":
@@ -214,8 +222,8 @@ nonzero. `--format json` carries the same distinction as `verdict` plus a
 non-null `input_error`.
 
 `PASS` here means the selected checks found nothing above `LOW` in the content
-lintlang extracted from these two files. It is not evidence that the agent is
-safe or runtime-correct.
+lintlang extracted from `/tmp/agent-fixed.yaml`. It is not evidence that the
+agent is safe or runtime-correct.
 
 ## Try the bundled example
 

--- a/tests/test_first_run_recipe.py
+++ b/tests/test_first_run_recipe.py
@@ -1,0 +1,131 @@
+"""The README's checkout-free first run must keep producing what it publishes.
+
+`README.md` → "First run without a checkout" tells a reader with no clone to
+write two small YAML files and scan them. This module is the single source of
+truth for those two fixtures: it extracts them straight out of the README, so
+the published recipe cannot drift away from the scanner that has to satisfy it.
+
+Pinned behaviour:
+
+* the first fixture reports the ``H1.1`` CRITICAL and exits ``1`` under
+  ``--fail-on fail`` — a successful detection, not a broken install;
+* the second fixture no longer reports ``H1.1``, scans ``PASS`` and exits ``0``;
+* an input that cannot be read stays the distinct ``ERROR`` verdict rather than
+  collapsing into the finding-threshold exit.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+import lintlang
+from lintlang.cli import main
+from lintlang.report import compute_verdict
+from lintlang.scanner import scan_file
+
+README = Path(__file__).resolve().parent.parent / "README.md"
+SECTION = "## First run without a checkout"
+HEREDOC = re.compile(r"<<'YAML'\n(.*?)\nYAML\n", re.DOTALL)
+
+
+def _readme_fixtures() -> list[str]:
+    text = README.read_text(encoding="utf-8")
+    start = text.index(SECTION)
+    end = text.index("\n## ", start + len(SECTION))
+    return HEREDOC.findall(text[start:end])
+
+
+@pytest.fixture(scope="module")
+def fixtures() -> list[str]:
+    bodies = _readme_fixtures()
+    assert len(bodies) == 2, (
+        "README 'First run without a checkout' must publish exactly two YAML "
+        f"fixtures; found {len(bodies)}"
+    )
+    return bodies
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    path = tmp_path / name
+    path.write_text(body + "\n", encoding="utf-8")
+    return path
+
+
+def _codes(result) -> set[str]:
+    return {f.code for f in result.structural_findings if f.code}
+
+
+def test_bad_fixture_reports_h1_1_and_blocks(fixtures, tmp_path):
+    path = _write(tmp_path, "agent.yaml", fixtures[0])
+    result = scan_file(path)
+
+    assert result.input_error is None
+    assert "H1.1" in _codes(result)
+    assert compute_verdict(result) == "FAIL"
+    assert main(["scan", str(path), "--fail-on", "fail"]) == 1
+
+
+def test_bad_fixture_severity_counts_match_the_published_line(fixtures, tmp_path):
+    """README quotes 'FAIL — 1 CRITICAL, 1 HIGH, 1 MEDIUM'; pin that arithmetic."""
+    path = _write(tmp_path, "agent.yaml", fixtures[0])
+    result = scan_file(path)
+
+    counts = Counter(f.severity.value for f in result.structural_findings)
+    assert counts == Counter({"critical": 1, "high": 1, "medium": 1}), counts
+
+
+def test_fixed_fixture_drops_h1_1_and_passes(fixtures, tmp_path):
+    path = _write(tmp_path, "agent-fixed.yaml", fixtures[1])
+    result = scan_file(path)
+
+    assert result.input_error is None
+    assert "H1.1" not in _codes(result)
+    assert result.structural_findings == []
+    assert compute_verdict(result) == "PASS"
+    assert main(["scan", str(path), "--fail-on", "fail"]) == 0
+
+
+def test_unscannable_input_stays_a_distinct_error(tmp_path):
+    missing = tmp_path / "does-not-exist.yaml"
+    result = scan_file(missing)
+
+    assert result.input_error is not None
+    assert compute_verdict(result) == "ERROR"
+    assert main(["scan", str(missing), "--fail-on", "fail"]) != 0
+
+
+def _section() -> str:
+    text = README.read_text(encoding="utf-8")
+    start = text.index(SECTION)
+    return text[start : text.index("\n## ", start + len(SECTION))]
+
+
+def test_section_publishes_exactly_the_scans_it_promises():
+    """The prose says three scans; drift here misleads a first-time reader."""
+    section = _section()
+    scans = re.findall(r"^lintlang scan .*$", section, re.MULTILINE)
+    assert len(scans) == 3, scans
+    assert "run three scans" in section
+
+
+def test_section_pins_the_packaged_release():
+    """A floating install stops being release-matched the moment 0.5.3 ages out."""
+    section = _section()
+    assert f"pip install lintlang=={lintlang.__version__}" in section
+    assert f"`lintlang {lintlang.__version__}` reports" in section
+
+
+def test_section_does_not_claim_the_install_is_offline():
+    """`pip install` reaches an index; only the scans are offline.
+
+    The earlier wording ("Nothing here reads ... the network") covered the
+    whole block including the install, which was not true.
+    """
+    section = _section()
+    assert "Only the install reaches the network" in section
+    assert "Every `lintlang scan` below is offline" in section
+    assert "Nothing here reads" not in section

--- a/tests/test_first_run_recipe.py
+++ b/tests/test_first_run_recipe.py
@@ -32,11 +32,22 @@ SECTION = "## First run without a checkout"
 HEREDOC = re.compile(r"<<'YAML'\n(.*?)\nYAML\n", re.DOTALL)
 
 
-def _readme_fixtures() -> list[str]:
+def _section() -> str:
+    """The published section, sliced once and reused by every check.
+
+    The section currently has a sibling after it, but it must keep working as
+    the last section in the file — `str.index` would raise there, so fall back
+    to end-of-file instead.
+    """
     text = README.read_text(encoding="utf-8")
     start = text.index(SECTION)
-    end = text.index("\n## ", start + len(SECTION))
-    return HEREDOC.findall(text[start:end])
+    next_heading = text.find("\n## ", start + len(SECTION))
+    end = len(text) if next_heading == -1 else next_heading
+    return text[start:end]
+
+
+def _readme_fixtures() -> list[str]:
+    return HEREDOC.findall(_section())
 
 
 @pytest.fixture(scope="module")
@@ -98,12 +109,6 @@ def test_unscannable_input_stays_a_distinct_error(tmp_path):
     assert main(["scan", str(missing), "--fail-on", "fail"]) != 0
 
 
-def _section() -> str:
-    text = README.read_text(encoding="utf-8")
-    start = text.index(SECTION)
-    return text[start : text.index("\n## ", start + len(SECTION))]
-
-
 def test_section_publishes_exactly_the_scans_it_promises():
     """The prose says three scans; drift here misleads a first-time reader."""
     section = _section()
@@ -129,3 +134,132 @@ def test_section_does_not_claim_the_install_is_offline():
     assert "Only the install reaches the network" in section
     assert "Every `lintlang scan` below is offline" in section
     assert "Nothing here reads" not in section
+
+
+def test_section_scopes_pass_to_the_fixed_file_only():
+    """Only the repaired fixture passes; the original still FAILs.
+
+    Earlier wording ("this pair of files scans PASS", "these two files") read
+    as though both fixtures came out clean, which contradicts the FAIL the
+    section publishes a few lines earlier.
+    """
+    section = _section()
+    assert "this pair of files scans" not in section
+    assert "these two files" not in section
+    assert "the fixed file scans `PASS — 0 findings`" in section
+    assert "the original\n`/tmp/agent.yaml` still scans `FAIL`" in section
+    assert "extracted from `/tmp/agent-fixed.yaml`" in section
+
+
+def test_section_extraction_survives_being_the_last_section(tmp_path, monkeypatch):
+    """`_section()` must not depend on a heading following the block."""
+    truncated = tmp_path / "README.md"
+    truncated.write_text(_section(), encoding="utf-8")
+    monkeypatch.setattr(f"{__name__}.README", truncated, raising=False)
+    monkeypatch.setitem(globals(), "README", truncated)
+
+    assert len(_readme_fixtures()) == 2
+    assert _section().startswith(SECTION)
+
+
+def test_section_publishes_an_explicit_latest_install():
+    """A reader who declines the pin needs the command, not just permission."""
+    section = _section()
+    assert "python -m pip install --upgrade lintlang" in section
+    assert "re-read the counts below as approximate" in section
+
+
+# --- outbound-network deny guard ------------------------------------------
+
+# Prepended to the CHILD script, so the denial is installed in the scanning
+# process before lintlang is imported rather than asserted from the parent. A
+# `sitecustomize.py` would shadow the interpreter's own, which on some builds
+# is what puts site-packages on the path.
+_DENY_OUTBOUND = """\
+import socket
+
+
+class OutboundNetworkDenied(RuntimeError):
+    pass
+
+
+def _deny(*args, **kwargs):
+    raise OutboundNetworkDenied("outbound network access attempted")
+
+
+socket.socket = _deny
+socket.create_connection = _deny
+socket.getaddrinfo = _deny
+"""
+
+# Both paths the README documents: the library entry point and the CLI.
+_OFFLINE_DRIVER = """\
+import json
+import sys
+
+from lintlang.cli import main
+from lintlang.report import compute_verdict
+from lintlang.scanner import scan_file
+
+bad, fixed, missing = sys.argv[1:4]
+
+result = scan_file(bad)
+payload = {
+    "scan_file_codes": sorted({f.code for f in result.structural_findings if f.code}),
+    "scan_file_verdict": compute_verdict(result),
+    "fixed_verdict": compute_verdict(scan_file(fixed)),
+    "missing_verdict": compute_verdict(scan_file(missing)),
+    "cli_bad": main(["scan", bad, "--fail-on", "fail"]),
+    "cli_fixed": main(["scan", fixed, "--fail-on", "fail"]),
+    "cli_missing": main(["scan", missing, "--fail-on", "fail"]),
+}
+print("RESULT " + json.dumps(payload))
+"""
+
+
+def test_documented_paths_run_with_outbound_network_denied(fixtures, tmp_path):
+    """The published offline claim, enforced inside the scanning process.
+
+    Exercises both documented paths — `scan_file` and the CLI — so the claim
+    covers what a reader actually runs, not just one of them.
+    """
+    import json
+    import os
+    import subprocess
+    import sys
+
+    bad = _write(tmp_path, "agent.yaml", fixtures[0])
+    fixed = _write(tmp_path, "agent-fixed.yaml", fixtures[1])
+    missing = tmp_path / "does-not-exist.yaml"
+
+    repo_src = Path(__file__).resolve().parent.parent / "src"
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "HOME": str(tmp_path / "no-such-home"),
+        "PYTHONPATH": str(repo_src),
+    }
+
+    # The guard must actually bite, or this test proves nothing.
+    proof = subprocess.run(
+        [sys.executable, "-c", _DENY_OUTBOUND + "\nimport socket\nsocket.socket()\n"],
+        capture_output=True, text=True, env=env, cwd=os.fspath(tmp_path), check=False,
+    )
+    assert proof.returncode != 0
+    assert "OutboundNetworkDenied" in proof.stderr
+
+    run = subprocess.run(
+        [sys.executable, "-c", _DENY_OUTBOUND + _OFFLINE_DRIVER,
+         str(bad), str(fixed), str(missing)],
+        capture_output=True, text=True, env=env, cwd=os.fspath(tmp_path), check=False,
+    )
+    assert run.returncode == 0, run.stderr
+    line = next(ln for ln in run.stdout.splitlines() if ln.startswith("RESULT "))
+    payload = json.loads(line[len("RESULT "):])
+
+    assert "H1.1" in payload["scan_file_codes"]
+    assert payload["scan_file_verdict"] == "FAIL"
+    assert payload["fixed_verdict"] == "PASS"
+    assert payload["missing_verdict"] == "ERROR"
+    assert payload["cli_bad"] == 1
+    assert payload["cli_fixed"] == 0
+    assert payload["cli_missing"] != 0


### PR DESCRIPTION
Adds a checkout-free, release-pinned LintLang 0.5.3 first run with fail, pass, and invalid-input behavior, plus regression coverage for the published commands and network boundary.

Verified:
- tests/test_first_run_recipe.py: 7 passed
- Ruff clean
- git diff --check clean
- released 0.5.3 behavior: FAIL/1, PASS/0, ERROR/nonzero

Hermes Gate is not configured in this repository; no out-of-scope CI initialization is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a first-run guide for scanning files without cloning a repository.
  - Documented `PASS`, `FAIL`, and `ERROR` results, including exit codes and JSON output details.
  - Added examples showing how descriptions and bounds can resolve findings.
  - Clarified that a `PASS` result does not guarantee agent safety or runtime correctness.

- **Tests**
  - Added coverage to verify the documented workflow and expected scanner results remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->