### PR TITLE
Add OpenSSF Scorecard supply-chain analysis

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,60 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+#
+# OpenSSF Scorecard runs a fixed, published set of supply-chain heuristics
+# (branch protection, pinned dependencies, CI tests present, etc.) and reports
+# a score. It is not a security certification and does not vouch for the
+# correctness or safety of this project's code.
+
+name: Scorecard supply-chain security
+
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '17 3 * * 1'
+  push:
+    branches: [main]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge.
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@faaca9a8f6edddba5725ffe5adefdab6669a2eca # v3.29.5
+        with:
+          sarif_file: results.sarif

--- a/tests/test_scorecard_workflow.py
+++ b/tests/test_scorecard_workflow.py
@@ -1,0 +1,48 @@
+"""Security contracts for the OpenSSF Scorecard workflow."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "scorecard.yml"
+SCORECARD_WORKFLOW = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+FULL_SHA = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+
+
+def _steps():
+    return [step for job in SCORECARD_WORKFLOW["jobs"].values() for step in job["steps"]]
+
+
+def test_scorecard_checkout_credentials_are_not_persisted():
+    checkout_steps = [step for step in _steps() if step.get("uses", "").startswith("actions/checkout@")]
+
+    assert checkout_steps
+    assert all(step.get("with", {}).get("persist-credentials") is False for step in checkout_steps)
+
+
+def test_scorecard_default_permissions_are_read_only():
+    assert SCORECARD_WORKFLOW["permissions"] == "read-all"
+
+
+def test_scorecard_job_grants_only_the_scopes_it_needs():
+    job_permissions = SCORECARD_WORKFLOW["jobs"]["analysis"]["permissions"]
+
+    assert job_permissions == {"security-events": "write", "id-token": "write"}
+
+
+def test_scorecard_actions_are_pinned_to_full_length_commit_shas():
+    pinned = [step["uses"] for step in _steps() if "uses" in step]
+
+    assert pinned
+    assert all(FULL_SHA.match(ref) for ref in pinned)
+
+
+def test_scorecard_runs_on_the_default_branch_and_its_schedule():
+    on = SCORECARD_WORKFLOW[True] if True in SCORECARD_WORKFLOW else SCORECARD_WORKFLOW["on"]
+
+    assert on["push"]["branches"] == ["main"]
+    assert "schedule" in on
+    assert "branch_protection_rule" in on


### PR DESCRIPTION
## Summary
- Adds the official [`actions/starter-workflows`](https://github.com/actions/starter-workflows/blob/main/code-scanning/scorecard.yml) OpenSSF Scorecard workflow (`.github/workflows/scorecard.yml`), triggered on push to `main`, weekly, and on branch-protection changes.
- Pins every action to a full-length commit SHA, reusing the exact `actions/checkout@v7.0.1` and `actions/upload-artifact@v7.0.1` pins already used in `ci.yml`/`publish.yml`/`proof-benchmark.yml`/`release-sync.yml`, and pins `github/codeql-action/upload-sarif` (left as a floating `@v3` tag in the upstream template) to its current release SHA.
- Grants only `permissions: read-all` by default, with the job scoped to `security-events: write` + `id-token: write` (needed to upload SARIF and publish/badge results) — no broader scopes.
- Adds `tests/test_scorecard_workflow.py`, following the existing `tests/test_ci_workflow.py` pattern, asserting: checkout never persists credentials, default permissions are read-only, the job's permission block is exactly the two scopes above, every `uses:` reference is pinned to a full 40-character commit SHA, and the trigger config targets `main` plus the weekly schedule and branch-protection event.

## Notes
- Scorecard produces a heuristic supply-chain score (branch protection, pinned deps, CI presence, etc.) — it is not a security certification and doesn't assert the code itself is safe or correct.
- `publish_results: true` only takes effect from the default branch, so the public score/badge won't populate until this merges to `main` and the scheduled/push-triggered run completes there.

## Test plan
- [x] `ruff check tests/test_scorecard_workflow.py` — clean
- [x] `pytest tests/test_scorecard_workflow.py -v` — 5/5 passed
- [x] `hermes-gate fast` — PASS (ruff, AST parse, diff-check all green)
- [ ] `hermes-gate review` (coderabbit) — provider unavailable both attempts (free-tier review quota exhausted, then a transient WebSocket disconnect); not a finding against this change
- [ ] First GitHub Actions run on this PR (verifying after open)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015UWsRu7uWtyX6JNr9S9NWb

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated OpenSSF Scorecard analysis to monitor supply-chain security.
  * Published security findings to the code-scanning dashboard and retained analysis results as artifacts.
  * Scheduled regular scans and scans on relevant repository changes.

* **Tests**
  * Added validation to ensure the security workflow follows required permission, credential, trigger, and action-pinning safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->