### PR TITLE
fix(citation): point project URL at canonical homepage

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ version: "0.5.3"
 date-released: "2026-09-02"
 license: "Apache-2.0"
 repository-code: "https://github.com/hermes-labs-ai/lintlang"
-url: "https://github.com/hermes-labs-ai/lintlang"
+url: "https://lintlang.ai/"
 abstract: >
   lintlang is a zero-LLM static linter for AI agent configurations, tool descriptions,
   and system prompts. It combines HERM v1.1 dimensional scoring (6 dimensions,


### PR DESCRIPTION
Updates `CITATION.cff` so `url` points to the canonical product homepage, `https://lintlang.ai/`, while `repository-code` remains the GitHub repository. Version, release date, repository URL, and DOI metadata were verified unchanged. Hermes Gate fast and review both pass with zero findings.