### PR TITLE
ci: archive releases to Software Heritage

### DIFF
--- a/.github/workflows/swh-archive.yml
+++ b/.github/workflows/swh-archive.yml
@@ -1,0 +1,19 @@
+name: Archive to Software Heritage
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Request Save Code Now archival
+        run: |
+          curl --fail --silent --show-error \
+            --request POST \
+            "https://archive.softwareheritage.org/api/1/origin/save/git/url/https://github.com/${GITHUB_REPOSITORY}/"
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/swh-archive.yml
+++ b/.github/workflows/swh-archive.yml
@@ -1,6 +1,13 @@
 name: Archive to Software Heritage
 
 on:
+  # release-sync.yml creates the GitHub Release with the workflow token, and
+  # GitHub does not fire release events for token-created releases, so the
+  # tag push is the trigger that actually runs. Save Code Now archives the
+  # whole origin, so a duplicate request on a manual release is harmless.
+  push:
+    tags:
+      - "v*"
   release:
     types: [published]
 
@@ -13,6 +20,8 @@ jobs:
       - name: Request Save Code Now archival
         run: |
           curl --fail --silent --show-error \
+            --connect-timeout 10 \
+            --max-time 60 \
             --request POST \
             "https://archive.softwareheritage.org/api/1/origin/save/git/url/https://github.com/${GITHUB_REPOSITORY}/"
         env:


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/swh-archive.yml`, requesting a Software Heritage Save Code Now capture on `release: published` and on a `v*` tag push (see the post-review note for why both).
- Reuses the workflow already merged in Hermes Blind and Claude Router; `${{ github.repository }}` supplies the repository dynamically.
- Adds no badge or additional public claim.

## Why
LintLang now has full snapshot `swh:1:snp:748cd2a72eb5d7c09f7cc18b8552c9944aa70e0f`, but no recurring release-triggered archival.

## Checks (original head d136631)
- `actionlint` and YAML parse — clean
- `ruff check src/ tests/` — clean
- `pytest` — 533 passed, 76 subtests passed
- `hermes-gate fast` — PASS
- Exact direct diff review — PASS after the configured review provider was rate-limited

## Post-review (head `37c284b`)
CodeRabbit found that `release-sync.yml` creates the GitHub Release with `${{ github.token }}`, and GitHub does not fire `release` events for token-created releases, so a `release: published`-only trigger never runs here.

- Fix taken: also trigger on `push: tags: ['v*']`, the event that actually produces a release in this repo. Save Code Now archives the whole origin, so a duplicate request from a manually published release is harmless. The reason is recorded in a comment on the trigger.
- Alternative the owner may prefer instead: call this workflow from `release-sync.yml`'s `github-release` job (via `workflow_call`, matching the repo's existing pattern) or create the release with a PAT/App token. Either keeps "archive only on a verified release" semantics; the tag trigger archives even if release-sync later fails verification.
- Also added `--connect-timeout 10` / `--max-time 60` to the curl request.
- Not added: a workflow-contract test for `swh-archive.yml` in the `tests/test_systemic_automation.py` style.

Checks on `37c284b` (cloud session, Linux, Python 3.12):
- YAML parse — clean
- `ruff check src/ tests/` — clean
- `pytest -q` — 530 passed, 3 skipped, 76 subtests passed
- `hermes-gate fast` — NOT_CONFIGURED in this checkout (no `.hermes/` profile in the repository); `coderabbit` CLI not available
- Hosted CI — 7/7 checks success on `37c284b`

## Test plan
- [ ] On the next tag push / GitHub Release, confirm Save Code Now succeeds and records a Software Heritage visit.

<!-- hermes-labs:attribution v1 -->
<!-- hermes-labs:selection autonomous -->
This contribution was autonomously selected and produced by agents through [Hermes Labs](https://hermes-labs.ai)’ engineering infrastructure. [Rolando Bosch](https://github.com/roli-lpci) is the responsible human contributor and authorized publication from his personal GitHub account.
<!-- /hermes-labs:attribution -->
