### PR TITLE
Add browser playground entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 **Product page:** [lintlang.ai](https://lintlang.ai/)
 
+**Try in your browser:** [hermes-labs.ai/lintlang#playground](https://hermes-labs.ai/lintlang#playground) runs a real LintLang scan locally in your browser, with no account, API key, model call, or upload.
+
 **LintLang statically analyzes the natural-language instructions that control
 AI agents, catching ambiguous tools, missing limits, and conflicting directives
 before runtime.**


### PR DESCRIPTION
Adds one prominent README path from the public repository to the existing browser playground. The linked trial runs a real LintLang scan locally in the browser without an account, API key, model call, or upload.\n\nValidation: hermes-gate fast PASS; hermes-gate review PASS with zero findings; git diff --check PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Try in your browser” link to the LintLang playground.
  * The playground runs scans locally without requiring an account, API key, model call, or file upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->