### PR TITLE
fix: pin MegaLinter plugin to LintLang 0.6.0

### DIFF
--- a/mega-linter-plugin-lintlang/README.md
+++ b/mega-linter-plugin-lintlang/README.md
@@ -24,7 +24,7 @@ PLUGINS:
 ```
 
 MegaLinter's plugin loader runs the descriptor's `install` step at run time
-(`pip install --no-cache-dir lintlang==0.5.3`) inside the existing MegaLinter
+(`pip install --no-cache-dir lintlang==0.6.0`) inside the existing MegaLinter
 image, then invokes:
 
 ```console
@@ -87,7 +87,8 @@ docker run --rm --platform linux/amd64 \
 
 The current selector was exercised in MegaLinter 8.8.0 with a workspace
 containing `AGENTS.md`, `bad-agent.yaml`, and unrelated repository metadata.
-The loader initialized `AI_LINTLANG`, installed LintLang 0.5.3, and selected
+The recorded MegaLinter 8.8.0 trial initialized `AI_LINTLANG`, installed
+LintLang 0.5.3, and selected
 only the two conventionally named instruction surfaces. The bad fixture
 produced the expected `FAIL`; after removing it, MegaLinter selected only
 `AGENTS.md` and exited 0. This is loader and selector compatibility evidence,

--- a/mega-linter-plugin-lintlang/lintlang.megalinter-descriptor.yml
+++ b/mega-linter-plugin-lintlang/lintlang.megalinter-descriptor.yml
@@ -26,4 +26,4 @@ linters:
       - lintlang scan agent.yaml tools.json --fail-on fail
     install:
       dockerfile:
-        - RUN pip install --no-cache-dir lintlang==0.5.3
+        - RUN pip install --no-cache-dir lintlang==0.6.0

--- a/tests/test_megalinter_plugin.py
+++ b/tests/test_megalinter_plugin.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import yaml
 
+from lintlang import __version__
 from lintlang.cli import main
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -38,7 +39,7 @@ def test_megalinter_descriptor_contract() -> None:
     assert linter["supported_cli_lint_modes"] == ["list_of_files"]
     assert linter["cli_lint_extra_args"] == ["scan", "--fail-on", "fail"]
     assert linter["install"]["dockerfile"] == [
-        "RUN pip install --no-cache-dir lintlang==0.5.3"
+        f"RUN pip install --no-cache-dir lintlang=={__version__}"
     ]
 
 


### PR DESCRIPTION
MegaLinter catalog PR [oxsecurity/megalinter#8899](https://github.com/oxsecurity/megalinter/pull/8899) loads this descriptor from `main`, which still installed LintLang 0.5.3 after the 0.6.0 release.

This updates the external plugin install pin to 0.6.0, keeps the historical 0.5.3 container-trial note explicit, and derives the descriptor contract expectation from the package version so it cannot silently drift again.

Validation:
- `python -m pytest -q` (549 passed, 76 subtests passed)
- `ruff check src/ tests/`
- `hermes-gate fast`
- `hermes-gate review` attempted; provider reported a rate limit, so no external review result was available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled LintLang runtime from version 0.5.3 to 0.6.0.
  * Updated documentation to reflect the newer runtime version and MegaLinter 8.8.0 validation.
  * Aligned automated checks with the current LintLang package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->