### PR TITLE
fix(h2,h4): stop flagging finite enumeration and domain invariants as false positives

### DIFF
--- a/src/lintlang/patterns.py
+++ b/src/lintlang/patterns.py
@@ -778,6 +778,10 @@ _UNBOUNDED_CONTINUATION_SIGNALS = re.compile(
     r"\b(?:indefinitely|forever|endlessly|continuously|perpetually|non-?stop|without\s+(?:end|stopping|limit))\b",
     re.IGNORECASE,
 )
+_NEGATED_UNBOUNDED_LOOP = re.compile(
+    r"\b(?:never|do\s+not|don'?t|should\s+not)\b\s*$",
+    re.IGNORECASE,
+)
 
 
 def _is_negated_retry_prohibition(text: str, retry_start: int) -> bool:
@@ -796,7 +800,23 @@ def _is_unbounded_loop_traversal(text: str, match: re.Match[str]) -> bool:
     continuation signal (e.g. "loop over tasks indefinitely").
     """
     window = text[match.end() : match.end() + 80]
-    return bool(_UNBOUNDED_CONTINUATION_SIGNALS.search(window))
+    signal = _UNBOUNDED_CONTINUATION_SIGNALS.search(window)
+    if signal is None:
+        return False
+
+    # A prohibition such as "do not loop over the queue indefinitely" must
+    # not be treated as an instruction to run indefinitely. Check both a
+    # negation immediately before the traversal and one attached to the
+    # continuation signal later in the same clause.
+    before_match = text[max(0, match.start() - 40) : match.start()]
+    if _NEGATED_UNBOUNDED_LOOP.search(before_match):
+        return False
+    before_signal = window[: signal.start()]
+    return not re.search(
+        r"\b(?:never|do\s+not|don'?t|should\s+not)\b(?:\s+\w+){0,6}\s*$",
+        before_signal,
+        re.IGNORECASE,
+    )
 
 
 def _is_bounded_verification_loop(text: str, match: re.Match[str]) -> bool:
@@ -1020,8 +1040,9 @@ EROSION_PATTERNS = [
 ]
 
 _CROSS_CONTEXT_PERSISTENCE_SIGNALS = re.compile(
-    r"\b(?:context|history|conversation|memory|session|thread|state|prior|previous|past|before|"
-    r"everything|results?|carry(?:ing|over)?|cross[- ]?(?:task|session|turn|request)|"
+    r"\b(?:context|history|conversation|memory|session|thread|prior|previous|past|before|"
+    r"carry(?:ing|over)?|cross[- ]?(?:task|session|turn|request)|"
+    r"across\s+(?:tasks?|sessions?|turns?|requests?)|between\s+(?:tasks?|sessions?|turns?|requests?)|"
     r"what\s+(?:the\s+)?user\s+(?:said|told|asked))\b",
     re.IGNORECASE,
 )

--- a/src/lintlang/patterns.py
+++ b/src/lintlang/patterns.py
@@ -752,13 +752,15 @@ CONSTRAINT_SIGNALS = [
 ]
 
 _RETRY_UNTIL_PATTERN = r"retry\s+(?:until|as\s+many\s+times)"
+_LOOP_OVER_THROUGH_PATTERN = r"loop\s+(?:through|over)"
 
 
 DANGEROUS_PATTERNS = [
     (r"keep\s+trying\s+until", "Unbounded retry loop — 'keep trying until' needs an explicit limit."),
     (_RETRY_UNTIL_PATTERN, "Unbounded retry — add max_retries or a fallback."),
     (r"don'?t\s+stop\s+until", "Negative termination condition — rephrase as a positive bound."),
-    (r"loop\s+(?:through|over|until)", "Potential infinite loop — ensure a max iteration count."),
+    (r"loop\s+until", "Potential infinite loop — ensure a max iteration count."),
+    (_LOOP_OVER_THROUGH_PATTERN, "Potential infinite loop — ensure a max iteration count."),
     (r"continue\s+(?:until|indefinitely)", "Unbounded continuation — add an explicit termination condition."),
 ]
 
@@ -772,12 +774,29 @@ _VERIFICATION_GUIDANCE = re.compile(
     re.IGNORECASE,
 )
 _NEGATED_RETRY_PROHIBITION = re.compile(r"\b(?:never|do\s+not|don'?t)\s+$", re.IGNORECASE)
+_UNBOUNDED_CONTINUATION_SIGNALS = re.compile(
+    r"\b(?:indefinitely|forever|endlessly|continuously|perpetually|non-?stop|without\s+(?:end|stopping|limit))\b",
+    re.IGNORECASE,
+)
 
 
 def _is_negated_retry_prohibition(text: str, retry_start: int) -> bool:
     """Return whether an adjacent negation forbids, rather than requires, retrying."""
     prefix = text[max(0, retry_start - 20) : retry_start]
     return bool(_NEGATED_RETRY_PROHIBITION.search(prefix))
+
+
+def _is_unbounded_loop_traversal(text: str, match: re.Match[str]) -> bool:
+    """Return whether ``loop over/through`` describes an unbounded loop, not enumeration.
+
+    ``loop over`` and ``loop through`` ordinarily introduce enumeration of a
+    finite collection ("loop through the search results") — that is normal
+    control flow, not a missing-constraint risk. Only treat it as a potential
+    infinite loop when the same clause also carries an explicit indefinite-
+    continuation signal (e.g. "loop over tasks indefinitely").
+    """
+    window = text[match.end() : match.end() + 80]
+    return bool(_UNBOUNDED_CONTINUATION_SIGNALS.search(window))
 
 
 def _is_bounded_verification_loop(text: str, match: re.Match[str]) -> bool:
@@ -839,6 +858,8 @@ def detect_h2(config: AgentConfig) -> list[Finding]:
             if _is_bounded_verification_loop(text, match):
                 continue
             if pattern == _RETRY_UNTIL_PATTERN and _is_negated_retry_prohibition(text, match.start()):
+                continue
+            if pattern == _LOOP_OVER_THROUGH_PATTERN and not _is_unbounded_loop_traversal(text, match):
                 continue
             start = max(0, match.start() - 20)
             end = min(len(text), match.end() + 40)
@@ -987,14 +1008,36 @@ BOUNDARY_SIGNALS = [
     "boundary",
 ]
 
+_ALWAYS_PERSIST_PATTERN = r"always\s+(?:keep|maintain|remember)"
+
 EROSION_PATTERNS = [
     (r"remember\s+everything", "Unbounded memory — context will grow until it erodes task boundaries."),
     (
         r"use\s+(?:all|entire)\s+(?:conversation|history|context)",
         "Referencing entire history without scoping — promotes boundary erosion.",
     ),
-    (r"always\s+(?:keep|maintain|remember)", "Persistence without scope — specify WHAT to persist and for HOW LONG."),
+    (_ALWAYS_PERSIST_PATTERN, "Persistence without scope — specify WHAT to persist and for HOW LONG."),
 ]
+
+_CROSS_CONTEXT_PERSISTENCE_SIGNALS = re.compile(
+    r"\b(?:context|history|conversation|memory|session|thread|state|prior|previous|past|before|"
+    r"everything|results?|carry(?:ing|over)?|cross[- ]?(?:task|session|turn|request)|"
+    r"what\s+(?:the\s+)?user\s+(?:said|told|asked))\b",
+    re.IGNORECASE,
+)
+
+
+def _is_cross_context_persistence(text: str, match: re.Match[str]) -> bool:
+    """Return whether ``always keep/maintain/remember`` targets cross-context state.
+
+    The verb alone is ambiguous: "always maintain backward compatibility" or
+    "always keep responses under 200 words" state a domain invariant, not an
+    instruction to carry state across tasks or sessions. Only flag it when the
+    object names context, memory, history, prior state/results, or cross-task/
+    session carryover.
+    """
+    window = text[match.end() : match.end() + 80]
+    return bool(_CROSS_CONTEXT_PERSISTENCE_SIGNALS.search(window))
 
 
 def detect_h4(config: AgentConfig) -> list[Finding]:
@@ -1029,6 +1072,8 @@ def detect_h4(config: AgentConfig) -> list[Finding]:
             matches = list(re.finditer(pattern, prompt, re.IGNORECASE))
             for match in matches:
                 if not _is_direct_match(scope, match.start(), match.end()):
+                    continue
+                if pattern == _ALWAYS_PERSIST_PATTERN and not _is_cross_context_persistence(prompt, match):
                     continue
                 start = max(0, match.start() - 20)
                 end = min(len(prompt), match.end() + 40)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -518,6 +518,15 @@ class TestH2:
             findings = detect_h2(AgentConfig(system_prompt=prompt))
             assert any(f.severity == Severity.CRITICAL for f in findings)
 
+    def test_negated_indefinite_loop_traversal_does_not_flag(self):
+        """A prohibition against indefinite traversal is not an unbounded-loop instruction."""
+        for prompt in (
+            "Do not loop over the queue indefinitely.",
+            "Never loop through the task list forever.",
+        ):
+            findings = detect_h2(AgentConfig(system_prompt=prompt))
+            assert not any(f.severity == Severity.CRITICAL for f in findings)
+
     def test_missing_constraints_with_tools(self):
         config = AgentConfig(
             system_prompt="You are an assistant. Use the tools to help.",
@@ -687,6 +696,8 @@ class TestH4:
             "Always maintain respect for the author's voice while improving clarity.",
             "Always maintain backward compatibility.",
             "Always keep responses under 200 words.",
+            "Always maintain state consistency.",
+            "Always keep results sorted.",
         ):
             findings = detect_h4(AgentConfig(system_prompt=prompt))
             assert not any("persistence without scope" in f.description.lower() for f in findings)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -499,6 +499,25 @@ class TestH2:
             findings = detect_h2(AgentConfig(system_prompt=prompt))
             assert any(f.severity == Severity.CRITICAL for f in findings)
 
+    def test_loop_over_through_finite_collection_does_not_flag(self):
+        """'Loop over/through' describing ordinary enumeration is not an infinite-loop risk."""
+        for prompt in (
+            "Loop through each file in the folder, appending its contents to the report.",
+            "Loop over the search results and extract the title of each one.",
+            "Loop through every brick and check if the ball's center is within its bounds.",
+        ):
+            findings = detect_h2(AgentConfig(system_prompt=prompt))
+            assert not any(f.severity == Severity.CRITICAL for f in findings)
+
+    def test_loop_over_through_with_indefinite_signal_still_flags(self):
+        """An explicit indefinite-continuation signal keeps 'loop over/through' as a real risk."""
+        for prompt in (
+            "Loop over the queue indefinitely, processing new items as they arrive.",
+            "Loop through the task list forever until told otherwise.",
+        ):
+            findings = detect_h2(AgentConfig(system_prompt=prompt))
+            assert any(f.severity == Severity.CRITICAL for f in findings)
+
     def test_missing_constraints_with_tools(self):
         config = AgentConfig(
             system_prompt="You are an assistant. Use the tools to help.",
@@ -661,6 +680,26 @@ class TestH4:
         )
         findings = detect_h4(config)
         assert any("entire history" in f.description.lower() for f in findings)
+
+    def test_always_persist_domain_invariant_does_not_flag(self):
+        """'Always keep/maintain/remember' over a domain object is not context-boundary erosion."""
+        for prompt in (
+            "Always maintain respect for the author's voice while improving clarity.",
+            "Always maintain backward compatibility.",
+            "Always keep responses under 200 words.",
+        ):
+            findings = detect_h4(AgentConfig(system_prompt=prompt))
+            assert not any("persistence without scope" in f.description.lower() for f in findings)
+
+    def test_always_persist_cross_context_still_flags(self):
+        """'Always keep/maintain/remember' naming context/history/prior state is still erosion risk."""
+        for prompt in (
+            "Always keep track of what the user said before.",
+            "Always remember the full conversation history so nothing is lost between requests.",
+            "Always maintain the previous session's state across tasks.",
+        ):
+            findings = detect_h4(AgentConfig(system_prompt=prompt))
+            assert any("persistence without scope" in f.description.lower() for f in findings)
 
     def test_long_prompt_no_boundaries(self):
         config = AgentConfig(system_prompt="x " * 300)  # Long prompt, no boundary markers


### PR DESCRIPTION
## Summary

H2 treated `loop over`/`loop through` as unconditional evidence of an unbounded loop, even for ordinary finite-collection traversal. It now requires an explicit indefinite-continuation signal in the same clause and preserves negated/bounded wording; `loop until` remains covered when it is genuinely indefinite.

H4's persistence verbs (`keep`, `maintain`, `remember`) matched the verb alone, so domain invariants read as cross-context persistence risk. It now requires the object to name context, memory, history, prior state, or cross-task/session carryover, while leaving ordinary domain invariants unflagged.

## Verification

Verified against live checkouts of `github/awesome-copilot` and `wshobson/agents`: H2 CRITICAL findings 20 to 7, with the seven remaining findings being genuine indefinite `loop until` phrasing; H4 findings 4 to 0, all four removed hits confirmed false positives.

- `pytest -q` — 556 passed, 76 subtests passed
- `pytest -q tests/test_patterns.py -k "TestH2 or TestH4"` — 23 passed
- `ruff check src/ tests/` — clean
- `hermes-gate fast` — PASS; `hermes-gate review` — PASS, 0 findings

No package-release, version, or generated artifacts were changed. The proposed change is limited to `src/lintlang/patterns.py` and `tests/test_patterns.py`.

This is detector calibration and does not claim that a clean static scan proves runtime correctness or safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced false positives for finite “loop through” or “loop over” instructions by requiring an explicit, same-clause signal of indefinite continuation.
  - Improved handling of negated looping language, including adverbs between the negation and traversal instruction.
  - Continued flagging negations that are not attached to the traversal clause.
  - Refined persistence detection to require cross-context state within the same clause.
  - Later-clause references and ordinary persistence instructions are no longer incorrectly flagged.

- **Tests**
  - Added coverage for clause-scoped looping and persistence detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->